### PR TITLE
fix: [EUDIW-156] Pin not asked after app reinstallation

### DIFF
--- a/ts/sagas/startup/checkConfiguredPinSaga.ts
+++ b/ts/sagas/startup/checkConfiguredPinSaga.ts
@@ -1,5 +1,5 @@
 import * as O from "fp-ts/lib/Option";
-import { call, take, select, put } from "typed-redux-saga/macro";
+import { call, take } from "typed-redux-saga/macro";
 import { StackActions } from "@react-navigation/native";
 import { navigateToOnboardingPinScreenAction } from "../../store/actions/navigation";
 import { createPinSuccess } from "../../store/actions/pinset";
@@ -10,8 +10,6 @@ import NavigationService from "../../navigation/NavigationService";
 import { isValidPinNumber } from "../../utils/pin";
 import ROUTES from "../../navigation/routes";
 import { isDevEnv } from "../../utils/environment";
-import { isFirstAppRun } from "../../store/reducers/onboarding";
-import { firstOnboardingCompleted } from "../../store/actions/onboarding";
 
 export function* checkConfiguredPinSaga(): Generator<
   ReduxSagaEffect,
@@ -21,9 +19,8 @@ export function* checkConfiguredPinSaga(): Generator<
   // We check whether the user has already created a unlock code by trying to retrieve
   // it from the Keychain
   const pinCode = yield* call(getPin);
-  const isFirstOnboarding = yield* select(isFirstAppRun);
 
-  if (O.isSome(pinCode) && !isFirstOnboarding) {
+  if (O.isSome(pinCode)) {
     if (isValidPinNumber(pinCode.value)) {
       if (isDevEnv) {
         yield* call(
@@ -40,15 +37,6 @@ export function* checkConfiguredPinSaga(): Generator<
 
   // and block until a unlock code is set
   const resultAction = yield* take(createPinSuccess);
-
-  /* If this is the first time the user opens the app, we need to mark the onboarding as done
-   * This must be done here because keychain values like the pin a persisted across app reinstalls, thus we need to
-   * make sure that the pin is set before marking the onboarding as done.
-   */
-  if (isFirstOnboarding) {
-    yield* put(firstOnboardingCompleted());
-  }
-
   yield* call(
     NavigationService.dispatchNavigationAction,
     StackActions.replace(ROUTES.MAIN)

--- a/ts/sagas/startup/checkConfiguredPinSaga.ts
+++ b/ts/sagas/startup/checkConfiguredPinSaga.ts
@@ -1,5 +1,5 @@
 import * as O from "fp-ts/lib/Option";
-import { call, take } from "typed-redux-saga/macro";
+import { call, take, select, put } from "typed-redux-saga/macro";
 import { StackActions } from "@react-navigation/native";
 import { navigateToOnboardingPinScreenAction } from "../../store/actions/navigation";
 import { createPinSuccess } from "../../store/actions/pinset";
@@ -10,6 +10,8 @@ import NavigationService from "../../navigation/NavigationService";
 import { isValidPinNumber } from "../../utils/pin";
 import ROUTES from "../../navigation/routes";
 import { isDevEnv } from "../../utils/environment";
+import { isFirstAppRun } from "../../store/reducers/onboarding";
+import { firstOnboardingCompleted } from "../../store/actions/onboarding";
 
 export function* checkConfiguredPinSaga(): Generator<
   ReduxSagaEffect,
@@ -19,8 +21,9 @@ export function* checkConfiguredPinSaga(): Generator<
   // We check whether the user has already created a unlock code by trying to retrieve
   // it from the Keychain
   const pinCode = yield* call(getPin);
+  const isFirstOnboarding = yield* select(isFirstAppRun);
 
-  if (O.isSome(pinCode)) {
+  if (O.isSome(pinCode) && !isFirstOnboarding) {
     if (isValidPinNumber(pinCode.value)) {
       if (isDevEnv) {
         yield* call(
@@ -37,6 +40,15 @@ export function* checkConfiguredPinSaga(): Generator<
 
   // and block until a unlock code is set
   const resultAction = yield* take(createPinSuccess);
+
+  /* If this is the first time the user opens the app, we need to mark the onboarding as done
+   * This must be done here because keychain values like the pin a persisted across app reinstalls, thus we need to
+   * make sure that the pin is set before marking the onboarding as done.
+   */
+  if (isFirstOnboarding) {
+    yield* put(firstOnboardingCompleted());
+  }
+
   yield* call(
     NavigationService.dispatchNavigationAction,
     StackActions.replace(ROUTES.MAIN)

--- a/ts/sagas/startup/checkIsFirstOnboardingSaga.ts
+++ b/ts/sagas/startup/checkIsFirstOnboardingSaga.ts
@@ -1,12 +1,9 @@
 import { StackActions } from "@react-navigation/native";
-import { call, put, select, take } from "typed-redux-saga/macro";
+import { call, select, take } from "typed-redux-saga/macro";
 import { ReduxSagaEffect } from "../../types/utils";
 import NavigationService from "../../navigation/NavigationService";
 import ROUTES from "../../navigation/routes";
-import {
-  firstOnboardingCompleted,
-  onBoardingCarouselCompleted
-} from "../../store/actions/onboarding";
+import { onBoardingCarouselCompleted } from "../../store/actions/onboarding";
 import { isFirstAppRun } from "../../store/reducers/onboarding";
 
 export function* checkIsFirstOnboardingSaga(): Generator<ReduxSagaEffect> {
@@ -21,7 +18,6 @@ export function* checkIsFirstOnboardingSaga(): Generator<ReduxSagaEffect> {
     );
 
     const resultAction = yield* take(onBoardingCarouselCompleted);
-    yield* put(firstOnboardingCompleted());
     return resultAction.payload;
   }
   return;

--- a/ts/sagas/startup/checkIsFirstOnboardingSaga.ts
+++ b/ts/sagas/startup/checkIsFirstOnboardingSaga.ts
@@ -15,7 +15,7 @@ export function* checkIsFirstOnboardingSaga(): Generator<ReduxSagaEffect> {
   const isFirstOnboarding = yield* select(isFirstAppRun);
 
   if (isFirstOnboarding) {
-    // Reset pin if it exists because on iOS keychain perstitence survives app deletion
+    // Reset pin if it exists because on iOS keychain persistence survives app deletion
     yield* call(deletePin);
     yield* call(
       NavigationService.dispatchNavigationAction,

--- a/ts/sagas/startup/checkIsFirstOnboardingSaga.ts
+++ b/ts/sagas/startup/checkIsFirstOnboardingSaga.ts
@@ -8,12 +8,15 @@ import {
   onBoardingCarouselCompleted
 } from "../../store/actions/onboarding";
 import { isFirstAppRun } from "../../store/reducers/onboarding";
+import { deletePin } from "../../utils/keychain";
 
 export function* checkIsFirstOnboardingSaga(): Generator<ReduxSagaEffect> {
   // We check whether the user has already open the app at least once
   const isFirstOnboarding = yield* select(isFirstAppRun);
 
   if (isFirstOnboarding) {
+    // Reset pin if it exists because on iOS keychain perstitence survives app deletion
+    yield* call(deletePin);
     yield* call(
       NavigationService.dispatchNavigationAction,
       // We use navigate to go to the Onboarding Screen

--- a/ts/sagas/startup/checkIsFirstOnboardingSaga.ts
+++ b/ts/sagas/startup/checkIsFirstOnboardingSaga.ts
@@ -1,9 +1,12 @@
 import { StackActions } from "@react-navigation/native";
-import { call, select, take } from "typed-redux-saga/macro";
+import { call, put, select, take } from "typed-redux-saga/macro";
 import { ReduxSagaEffect } from "../../types/utils";
 import NavigationService from "../../navigation/NavigationService";
 import ROUTES from "../../navigation/routes";
-import { onBoardingCarouselCompleted } from "../../store/actions/onboarding";
+import {
+  firstOnboardingCompleted,
+  onBoardingCarouselCompleted
+} from "../../store/actions/onboarding";
 import { isFirstAppRun } from "../../store/reducers/onboarding";
 
 export function* checkIsFirstOnboardingSaga(): Generator<ReduxSagaEffect> {
@@ -18,6 +21,7 @@ export function* checkIsFirstOnboardingSaga(): Generator<ReduxSagaEffect> {
     );
 
     const resultAction = yield* take(onBoardingCarouselCompleted);
+    yield* put(firstOnboardingCompleted());
     return resultAction.payload;
   }
   return;

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -1,10 +1,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import {
-  Body,
   ButtonText,
   ContentWrapper,
-  HeaderFirstLevel,
-  ListItemNav,
   ListItemSwitch,
   useIOToast
 } from "@pagopa/io-app-design-system";
@@ -16,7 +13,6 @@ import { isDebugModeEnabledSelector } from "../../store/reducers/debug";
 import { setDebugModeEnabled } from "../../store/actions/debug";
 import I18n from "../../i18n";
 import { resetFirstOnboarding } from "../../store/actions/onboarding";
-import { deletePin } from "../../utils/keychain";
 import { resetPreferences } from "../../store/actions/persistedPreferences";
 import { useHeaderSecondLevel } from "../../hooks/useHeaderSecondLevel";
 import { IOScrollViewWithLargeHeader } from "../../components/ui/IOScrollViewWithLargeHeader";
@@ -75,7 +71,6 @@ const ProfileMainScreen = () => {
   const resetAppStart = useCallback(() => {
     reduxDispatch(resetFirstOnboarding());
     reduxDispatch(resetPreferences());
-    deletePin();
     show(I18n.t("profile.main.closeAppWarning"));
   }, [reduxDispatch, show]);
   return (


### PR DESCRIPTION
## Short description
On iOS the PIN is persisted through the keychain which survives an app reinstallation. Thus, the onboarding flow doesn't ask for a PIN creation if the user uninstalls and reinstalls the app.

## List of changes proposed in this pull request
- Delete the pin if a new onboarding is detected;
- Remove pin deletion when using the reset button in the debug section as this is directly done in the onboarding saga.

## How to test
Reinstall the app and test the first onboarding. Reinstall the app and check if the PIN creation flow is shown properly.