### PR TITLE
fix: [WLEO-239] Navigation stack not resetted on pid issuance failure or success

### DIFF
--- a/ts/features/wallet/screens/pidIssuance/PidIssuanceRequest.tsx
+++ b/ts/features/wallet/screens/pidIssuance/PidIssuanceRequest.tsx
@@ -21,6 +21,7 @@ import LoadingScreenContent from '../../../../components/LoadingScreenContent';
 import CredentialPreviewClaimsList from '../../components/credential/CredentialPreviewClaimsList';
 import {StoredCredential} from '../../utils/types';
 import {addCredentialWithIdentification} from '../../store/credentials';
+import {useNavigateToWalletWithReset} from '../../../../hooks/useNavigateToWalletWithReset';
 
 /**
  * Screen which starts and handles the PID issuance flow.
@@ -34,6 +35,7 @@ const PidIssuanceRequest = () => {
   const dispatch = useAppDispatch();
   const {error, success, loading} = useAppSelector(selectPidIssuanceStatus);
   const pid = useAppSelector(selectPidIssuanceData);
+  const {navigateToWallet} = useNavigateToWalletWithReset();
 
   useEffect(() => {
     dispatch(setPidIssuanceRequest());
@@ -51,10 +53,6 @@ const PidIssuanceRequest = () => {
     title: '',
     canGoBack: success.status
   });
-
-  const onCancel = () => {
-    navigation.navigate('MAIN_TAB_NAV');
-  };
 
   const PidPreview = ({credential}: {credential: StoredCredential}) => (
     <>
@@ -79,7 +77,7 @@ const PidIssuanceRequest = () => {
           },
           secondary: {
             label: t('global:buttons.cancel'),
-            onPress: onCancel
+            onPress: navigateToWallet
           },
           type: 'TwoButtons'
         }}

--- a/ts/features/wallet/screens/pidIssuance/PidIssuanceSuccess.tsx
+++ b/ts/features/wallet/screens/pidIssuance/PidIssuanceSuccess.tsx
@@ -1,9 +1,9 @@
-import {useNavigation} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
 import React from 'react';
 import {OperationResultScreenContent} from '../../../../components/screens/OperationResultScreenContent';
 import {resetPidIssuance} from '../../store/pidIssuance';
 import {useAppDispatch} from '../../../../store';
+import {useNavigateToWalletWithReset} from '../../../../hooks/useNavigateToWalletWithReset';
 
 /**
  * Success screen for the PID issuance flow.
@@ -12,8 +12,8 @@ import {useAppDispatch} from '../../../../store';
  */
 const PidIssuanceSuccess = () => {
   const {t} = useTranslation(['wallet']);
-  const navigation = useNavigation();
   const dispatch = useAppDispatch();
+  const {navigateToWallet} = useNavigateToWalletWithReset();
 
   return (
     <OperationResultScreenContent
@@ -25,7 +25,7 @@ const PidIssuanceSuccess = () => {
         label: t('wallet:pidIssuance.success.buttons.add'),
         onPress: () => {
           dispatch(resetPidIssuance());
-          navigation.navigate('MAIN_TAB_NAV');
+          navigateToWallet();
         }
       }}
       secondaryAction={{
@@ -33,7 +33,7 @@ const PidIssuanceSuccess = () => {
         accessibilityLabel: t('wallet:pidIssuance.success.buttons.later'),
         onPress: () => {
           dispatch(resetPidIssuance());
-          navigation.navigate('MAIN_TAB_NAV');
+          navigateToWallet();
         }
       }}
     />


### PR DESCRIPTION
## Short description

This PR fixes an issues where the navigation stack didn't get reset on pid issuance failure or success.

## List of changes proposed in this pull request

- Replace manual navigation with the `useNavigateToWalletWithReset` hook which correctly resets the navigation stack, preventing going back from the tab navigator.

## How to test
This can be tested by obtaining a PID and after going back to the main wallet screen try to swipe back or use the hardware back button on Android. You shouldn't be able to get back to the success screen.
