### PR TITLE
fix: [WLEO-265] Fix debug utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@react-navigation/native-stack": "^7.0.4",
     "@reduxjs/toolkit": "^2.3.0",
     "@textlint/markdown-to-ast": "^14.3.0",
+    "@types/jest": "^29.5.14",
     "i18next": "^23.16.5",
     "io-react-native-secure-storage": "^0.1.1",
     "js-base64": "^3.7.7",

--- a/ts/hooks/useDebugInfo.ts
+++ b/ts/hooks/useDebugInfo.ts
@@ -11,7 +11,7 @@ import {useAppDispatch, useAppSelector} from '../store';
  * Sets debug data for the mounted component. Removes it when the component is unmounted
  * @param data Data to be displayes in debug mode
  */
-export const useDebugInfo = (data: Record<string, any>) => {
+export const useDebugInfo = (data: Record<string, unknown>) => {
   const dispatch = useAppDispatch();
   const isDebug = useAppSelector(selectIsDebugModeEnabled);
 

--- a/ts/store/reducers/__tests__/debug.test.ts
+++ b/ts/store/reducers/__tests__/debug.test.ts
@@ -1,0 +1,68 @@
+import {
+  debugReducer,
+  resetDebugData,
+  setDebugData,
+  selectDebugData
+} from '../debug';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+const internalSelectDebugData: (
+  state: ReturnType<typeof debugReducer>
+) => ReturnType<typeof selectDebugData> = state => state.debugData;
+
+describe('debug', () => {
+  it('should return the debug data without the undefined values', () => {
+    const state = debugReducer(
+      {
+        isDebugModeEnabled: true,
+        debugData: {}
+      } as any,
+      setDebugData({not_visible: undefined, visible: 'visible'})
+    );
+    expect(internalSelectDebugData(state)).toEqual({visible: 'visible'});
+  });
+  it('should remove the debug data when resetDebugData is called', () => {
+    const state = debugReducer(
+      {
+        isDebugModeEnabled: true,
+        debugData: {A: 'A', B: 'B', C: 'C'}
+      } as any,
+      resetDebugData(['A', 'B'])
+    );
+    expect(internalSelectDebugData(state)).toEqual({C: 'C'});
+  });
+  it('should merge and/or override data', () => {
+    const state = debugReducer(
+      {
+        isDebugModeEnabled: true,
+        debugData: {A: 'A', B: 'B', C: 'C'}
+      } as any,
+      setDebugData({C: 'Updated!', D: 'D', E: 'E'})
+    );
+    expect(internalSelectDebugData(state)).toEqual({
+      A: 'A',
+      B: 'B',
+      C: 'Updated!',
+      D: 'D',
+      E: 'E'
+    });
+  });
+  it('should remove undefined values', () => {
+    const state = debugReducer(
+      {
+        isDebugModeEnabled: true,
+        debugData: {A: 'A', B: 'B', C: 'C'} // <- C has a value
+      } as any,
+      setDebugData({C: undefined, D: 'D', E: 'E'}) // <- C is updated to undefined
+    );
+    expect(internalSelectDebugData(state)).toEqual({
+      A: 'A',
+      B: 'B',
+      D: 'D',
+      E: 'E'
+    });
+  });
+});

--- a/ts/store/reducers/debug.ts
+++ b/ts/store/reducers/debug.ts
@@ -13,7 +13,7 @@ import {RootState} from '../types';
  */
 type DebugState = Readonly<{
   isDebugModeEnabled: boolean;
-  debugData: Record<string, any>;
+  debugData: Record<string, unknown>;
 }>;
 
 // Initial state for the debug slice
@@ -33,8 +33,11 @@ const debugSlice = createSlice({
       state.isDebugModeEnabled = action.payload.state;
       state.debugData = {};
     },
-    setDebugData: (state, action: PayloadAction<Record<string, any>>) => {
-      state.debugData = _.merge(state.debugData, action.payload);
+    setDebugData: (state, action: PayloadAction<Record<string, unknown>>) => {
+      state.debugData = {
+        ...state.debugData,
+        ...action.payload
+      }
     },
     resetDebugData(state, action: PayloadAction<ReadonlyArray<string>>) {
       state.debugData = Object.fromEntries(

--- a/ts/store/reducers/debug.ts
+++ b/ts/store/reducers/debug.ts
@@ -37,7 +37,7 @@ const debugSlice = createSlice({
       state.debugData = {
         ...state.debugData,
         ...action.payload
-      }
+      };
     },
     resetDebugData(state, action: PayloadAction<ReadonlyArray<string>>) {
       state.debugData = Object.fromEntries(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3617,6 +3617,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jest@npm:^29.5.14":
+  version: 29.5.14
+  resolution: "@types/jest@npm:29.5.14"
+  dependencies:
+    expect: ^29.0.0
+    pretty-format: ^29.0.0
+  checksum: 18dba4623f26661641d757c63da2db45e9524c9be96a29ef713c703a9a53792df9ecee9f7365a0858ddbd6440d98fe6b65ca67895ca5884b73cbc7ffc11f3838
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -7139,7 +7149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^29.7.0":
+"expect@npm:^29.0.0, expect@npm:^29.7.0":
   version: 29.7.0
   resolution: "expect@npm:29.7.0"
   dependencies:
@@ -8301,6 +8311,7 @@ __metadata:
     "@react-navigation/native-stack": ^7.0.4
     "@reduxjs/toolkit": ^2.3.0
     "@textlint/markdown-to-ast": ^14.3.0
+    "@types/jest": ^29.5.14
     "@types/lodash": ^4.17.13
     "@types/react": ^18.2.6
     "@types/react-test-renderer": ^18.0.0
@@ -11811,7 +11822,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.0.3, pretty-format@npm:^29.7.0":
+"pretty-format@npm:^29.0.0, pretty-format@npm:^29.0.3, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
   dependencies:


### PR DESCRIPTION
## Short description

This PR replicates changes done for [\[SIW-1985\]](https://github.com/pagopa/io-app/pull/6611), fixing an issue with the `useDeugInfo` hook: the problem was in the `setDebugData` action of the `debugReducer`, that used Loadhash's `merge` method improperly. Now, the `merge` invocation has been replaced with a spread assignment.

## List of changes proposed in this pull request

- `ts/store/reducers/debug.ts` : changed `DebugState.debugData`'s records' value type from `any` to `unknown`, changed `setDebugData` from a loadhash `merge` to a spread assignment.

- `ts/hooks/useDebugInfo.ts` : changed `useDebugInfo`'s data argument records' value type from `any` to `unknown`.

- `ts/store/reducers/__tests__/debug.test.ts` : adapted test of original [PR](https://github.com/pagopa/io-app/pull/6611).

- `package.json` : Added `@types/jest` dependency.

## How to test

By integrating changes of [\[SIW-1985\]](https://github.com/pagopa/io-app/pull/6611), a test has been introduced in `ts/store/reducers/__tests__/debug.test.ts`.

Moreover, the functionality can be tested inside the application:

1. After installing the application, enable debug mode.
2. Without obtaining a PID, go to the `Show QR` screen, and attempt a remote presentation: it should generate two errors; click on the ladybug icon and check that they are displayed correctly.
3. Another error situation can be crafted by using the `1.3.0` version of the `io-react-native-wallet` library (so, modification to `package.json`, a `yarn install` and a `yarn start --reset-cache` are needed). This version will generate an error when trying to obtain a PID, click on the ladybug icon and check that the error is displayed correctly.

[SIW-1985]: https://pagopa.atlassian.net/browse/SIW-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIW-1985]: https://pagopa.atlassian.net/browse/SIW-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ