### PR TITLE
feat: [WLEO-262] Add mdoc-openid4vp custom schema

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,6 +46,12 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="eudi-openid4vp" />
       </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="mdoc-openid4vp" />
+      </intent-filter>
     </activity>
 
     <service

--- a/ios/IoEudiwApp/Info.plist
+++ b/ios/IoEudiwApp/Info.plist
@@ -105,6 +105,12 @@
           <string>eudi-openid4vp</string>
         </array>
       </dict>
+      <dict>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>mdoc-openid4vp</string>
+        </array>
+      </dict>
     </array>
   </dict>
 </plist>

--- a/ts/navigation/deepLinkSchemas.ts
+++ b/ts/navigation/deepLinkSchemas.ts
@@ -4,5 +4,6 @@
 export const PRESENTATION_INTERNAL_LINKS = [
   'haip://',
   'openid4vp://',
-  'eudi-openid4vp://'
+  'eudi-openid4vp://',
+  'mdoc-openid4vp://'
 ];


### PR DESCRIPTION
## Short description

This PR aims to add another custom schema useful for remote presentation in same-device scenario. In particular, `mdoc-openid4vp` custom schema need when an mDL in format `mdoc` is requested from Relying Party

## List of changes proposed in this pull request

- Add `mdoc-openid4vp` as intent-filter in AndroidManifest
- Add `mdoc-openid4vp` as CFBundleURLSchemes in Info.plist

## How to test

We have tested during Interop Test at Utrecht, not exists a real use case to test at the moment.
