### PR TITLE
fix: [WLEO-278,WLEO-301] Reset wallet state correctly

### DIFF
--- a/ts/features/wallet/saga/credential.ts
+++ b/ts/features/wallet/saga/credential.ts
@@ -20,7 +20,7 @@ import {
   setIdentificationStarted,
   setIdentificationUnidentified
 } from '../../../store/reducers/identification';
-import {navigate} from '../../../navigation/utils';
+import {navigateWithReset} from '../../../navigation/utils';
 import {
   addCredential,
   addCredentialWithIdentification
@@ -245,7 +245,7 @@ function* storeCredentialWithIdentification(
   if (setIdentificationIdentified.match(resAction)) {
     yield* put(addCredential({credential: action.payload.credential}));
     yield* put(resetCredentialIssuance());
-    navigate('MAIN_TAB_NAV');
+    navigateWithReset('MAIN_TAB_NAV');
     IOToast.success(i18next.t('buttons.done', {ns: 'global'}));
   } else {
     return;

--- a/ts/features/wallet/screens/credentialIssuance/CredentialFailure.tsx
+++ b/ts/features/wallet/screens/credentialIssuance/CredentialFailure.tsx
@@ -10,6 +10,7 @@ import {
   selectCredentialIssuancePreAuthError
 } from '../../store/credentialIssuance';
 import {useDebugInfo} from '../../../../hooks/useDebugInfo';
+import {useNavigateToWalletWithReset} from '../../../../hooks/useNavigateToWalletWithReset';
 
 /**
  * Filure screen of the credential issuance flow.
@@ -17,7 +18,7 @@ import {useDebugInfo} from '../../../../hooks/useDebugInfo';
  */
 const CredentialFailure = () => {
   const {t} = useTranslation(['global', 'wallet']);
-  const navigation = useNavigation();
+  const {navigateToWallet} = useNavigateToWalletWithReset();
   const dispatch = useAppDispatch();
   const postError = useAppSelector(selectCredentialIssuancePostAuthError);
   const preError = useAppSelector(selectCredentialIssuancePreAuthError);
@@ -28,7 +29,7 @@ const CredentialFailure = () => {
 
   const onPress = () => {
     dispatch(resetCredentialIssuance());
-    navigation.navigate('MAIN_TAB_NAV');
+    navigateToWallet();
   };
 
   return (

--- a/ts/features/wallet/screens/credentialIssuance/CredentialFailure.tsx
+++ b/ts/features/wallet/screens/credentialIssuance/CredentialFailure.tsx
@@ -1,4 +1,3 @@
-import {useNavigation} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
 import React from 'react';
 import {useAppDispatch, useAppSelector} from '../../../../store';

--- a/ts/features/wallet/store/attestation.ts
+++ b/ts/features/wallet/store/attestation.ts
@@ -4,6 +4,7 @@ import {PersistConfig, persistReducer} from 'redux-persist';
 import {RootState} from '../../../store/types';
 import secureStoragePersistor from '../../../store/persistors/secureStorage';
 import {preferencesReset} from '../../../store/reducers/preferences';
+import {Lifecycle, setLifecycle} from './lifecycle';
 
 /* State type definition for the attestation slice
  * attestation - The wallet instance attestation
@@ -32,6 +33,13 @@ const attestationSlice = createSlice({
   extraReducers: builder => {
     // This happens when the whole app state is reset
     builder.addCase(preferencesReset, _ => initialState);
+    // This happens when the wallet state is reset
+    builder.addCase(setLifecycle, (state, action) => {
+      if (action.payload.lifecycle === Lifecycle.LIFECYCLE_OPERATIONAL) {
+        return initialState;
+      }
+      return state;
+    });
   }
 });
 

--- a/ts/features/wallet/store/attestation.ts
+++ b/ts/features/wallet/store/attestation.ts
@@ -4,7 +4,7 @@ import {PersistConfig, persistReducer} from 'redux-persist';
 import {RootState} from '../../../store/types';
 import secureStoragePersistor from '../../../store/persistors/secureStorage';
 import {preferencesReset} from '../../../store/reducers/preferences';
-import {Lifecycle, setLifecycle} from './lifecycle';
+import {resetLifecycle} from './lifecycle';
 
 /* State type definition for the attestation slice
  * attestation - The wallet instance attestation
@@ -34,12 +34,7 @@ const attestationSlice = createSlice({
     // This happens when the whole app state is reset
     builder.addCase(preferencesReset, _ => initialState);
     // This happens when the wallet state is reset
-    builder.addCase(setLifecycle, (state, action) => {
-      if (action.payload.lifecycle === Lifecycle.LIFECYCLE_OPERATIONAL) {
-        return initialState;
-      }
-      return state;
-    });
+    builder.addCase(resetLifecycle, _ => initialState);
   }
 });
 

--- a/ts/features/wallet/store/credentials.ts
+++ b/ts/features/wallet/store/credentials.ts
@@ -6,7 +6,7 @@ import {StoredCredential} from '../utils/types';
 import {RootState} from '../../../store/types';
 import {preferencesReset} from '../../../store/reducers/preferences';
 import {wellKnownCredential} from '../utils/credentials';
-import {Lifecycle, setLifecycle} from './lifecycle';
+import {resetLifecycle} from './lifecycle';
 
 /* State type definition for the credentials slice.
  * This is stored as an array to avoid overhead due to map not being serializable,
@@ -79,12 +79,7 @@ const credentialsSlice = createSlice({
     // This happens when the whole app state is reset
     builder.addCase(preferencesReset, _ => initialState);
     // This happens when the wallet state is reset
-    builder.addCase(setLifecycle, (state, action) => {
-      if (action.payload.lifecycle === Lifecycle.LIFECYCLE_OPERATIONAL) {
-        return initialState;
-      }
-      return state;
-    });
+    builder.addCase(resetLifecycle, _ => initialState);
   }
 });
 

--- a/ts/features/wallet/store/credentials.ts
+++ b/ts/features/wallet/store/credentials.ts
@@ -6,6 +6,7 @@ import {StoredCredential} from '../utils/types';
 import {RootState} from '../../../store/types';
 import {preferencesReset} from '../../../store/reducers/preferences';
 import {wellKnownCredential} from '../utils/credentials';
+import {Lifecycle, setLifecycle} from './lifecycle';
 
 /* State type definition for the credentials slice.
  * This is stored as an array to avoid overhead due to map not being serializable,
@@ -77,6 +78,13 @@ const credentialsSlice = createSlice({
   extraReducers: builder => {
     // This happens when the whole app state is reset
     builder.addCase(preferencesReset, _ => initialState);
+    // This happens when the wallet state is reset
+    builder.addCase(setLifecycle, (state, action) => {
+      if (action.payload.lifecycle === Lifecycle.LIFECYCLE_OPERATIONAL) {
+        return initialState;
+      }
+      return state;
+    });
   }
 });
 

--- a/ts/features/wallet/store/instance.ts
+++ b/ts/features/wallet/store/instance.ts
@@ -2,7 +2,7 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 import {RootState} from '../../../store/types';
 import {preferencesReset} from '../../../store/reducers/preferences';
-import {Lifecycle, setLifecycle} from './lifecycle';
+import {resetLifecycle} from './lifecycle';
 
 /* State type definition for the instance slice
  * keyTag - The keytag bound to the wallet instance
@@ -32,12 +32,7 @@ const instanceSlice = createSlice({
     // This happens when the whole app state is reset
     builder.addCase(preferencesReset, _ => initialState);
     // This happens when the wallet state is reset
-    builder.addCase(setLifecycle, (state, action) => {
-      if (action.payload.lifecycle === Lifecycle.LIFECYCLE_OPERATIONAL) {
-        return initialState;
-      }
-      return state;
-    });
+    builder.addCase(resetLifecycle, _ => initialState);
   }
 });
 

--- a/ts/features/wallet/store/instance.ts
+++ b/ts/features/wallet/store/instance.ts
@@ -2,6 +2,7 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 import {RootState} from '../../../store/types';
 import {preferencesReset} from '../../../store/reducers/preferences';
+import {Lifecycle, setLifecycle} from './lifecycle';
 
 /* State type definition for the instance slice
  * keyTag - The keytag bound to the wallet instance
@@ -30,6 +31,13 @@ const instanceSlice = createSlice({
   extraReducers: builder => {
     // This happens when the whole app state is reset
     builder.addCase(preferencesReset, _ => initialState);
+    // This happens when the wallet state is reset
+    builder.addCase(setLifecycle, (state, action) => {
+      if (action.payload.lifecycle === Lifecycle.LIFECYCLE_OPERATIONAL) {
+        return initialState;
+      }
+      return state;
+    });
   }
 });
 

--- a/ts/features/wallet/store/lifecycle.ts
+++ b/ts/features/wallet/store/lifecycle.ts
@@ -55,7 +55,7 @@ const lifecycleSlice = createSlice({
 /**
  * Exports the actions for the lifecycle slice.
  */
-export const {setLifecycle} = lifecycleSlice.actions;
+export const {setLifecycle, resetLifecycle} = lifecycleSlice.actions;
 
 export const {reducer: lifecycleReducer} = lifecycleSlice;
 

--- a/ts/navigation/utils.ts
+++ b/ts/navigation/utils.ts
@@ -6,21 +6,39 @@ import {RootStackParamList} from './RootStacknavigator';
  */
 export const navigationRef = createNavigationContainerRef<RootStackParamList>();
 
-/**
- * Navigate to a screen outside of React context.
- * @param args - The screen name and optional params.
- */
-export function navigate<RouteName extends keyof RootStackParamList>(
-  ...args: RouteName extends unknown
+type NavigationUtilParams<RouteName extends keyof RootStackParamList> =
+  RouteName extends unknown
     ? undefined extends RootStackParamList[RouteName]
       ?
           | [screen: RouteName]
           | [screen: RouteName, params: RootStackParamList[RouteName]]
       : [screen: RouteName, params: RootStackParamList[RouteName]]
-    : never
+    : never;
+
+/**
+ * Navigate to a screen outside of React context.
+ * @param args - The screen name and optional params.
+ */
+export function navigate<RouteName extends keyof RootStackParamList>(
+  ...args: NavigationUtilParams<RouteName>
 ) {
   if (navigationRef.isReady()) {
     navigationRef.navigate(...args);
+  }
+}
+
+/**
+ * Navigate to a screen resetting navigation state outside of React context.
+ * @param args - The screen name and optional params.
+ */
+export function navigateWithReset<RouteName extends keyof RootStackParamList>(
+  ...args: NavigationUtilParams<RouteName>
+) {
+  if (navigationRef.isReady()) {
+    navigationRef.reset({
+      index: 0,
+      routes: [{name: args[0], params: args[1]}]
+    });
   }
 }
 

--- a/ts/screens/Settings.tsx
+++ b/ts/screens/Settings.tsx
@@ -12,7 +12,7 @@ import {useTranslation} from 'react-i18next';
 import {useHeaderSecondLevel} from '../hooks/useHeaderSecondLevel';
 import {IOScrollViewWithLargeHeader} from '../components/IOScrollViewWithLargeHeader';
 import {useAppDispatch, useAppSelector} from '../store';
-import {Lifecycle, setLifecycle} from '../features/wallet/store/lifecycle';
+import {resetLifecycle} from '../features/wallet/store/lifecycle';
 import {preferencesReset} from '../store/reducers/preferences';
 import {
   selectIsDebugModeEnabled,
@@ -39,7 +39,7 @@ const Settings = () => {
     {
       label: t('settings.reset.walletReset'),
       onPress: () => {
-        dispatch(setLifecycle({lifecycle: Lifecycle.LIFECYCLE_OPERATIONAL}));
+        dispatch(resetLifecycle());
         toast.success(t('generics.success'));
       }
     },


### PR DESCRIPTION
## Short description

This PR adds listeners to a specific set of stores for the `resetLifecycle` action fired when resetting the wallet (so not the whole application), so that they can clear state accordingly. Previously no store listened to such event, and so there wasn't a full reset of the wallet data (e.g. the driving license survived the reset). The listeners have been added only to the stores it was considered necessary to perform a state reset, which are listed below.

Moreover, this PR solves [\[WLEO-301\]](https://pagopa.atlassian.net/jira/software/c/projects/WLEO/boards/601?assignee=712020%3Adcf931c4-2a77-403b-b539-7a018b6d504c&selectedIssue=WLEO-301) by creating a new helper function derived from the navigate one in ts/navigation/utils.ts that has the same behavior of the useNavigateToWalletWithReset hook and that is invoked in ts/features/wallet/saga/credential.ts.storeCredentialIdentification.

[\[WLEO-301\]](https://pagopa.atlassian.net/jira/software/c/projects/WLEO/boards/601?assignee=712020%3Adcf931c4-2a77-403b-b539-7a018b6d504c&selectedIssue=WLEO-301)'s description specified that the navigation problem might be present not only inside the credential issuance flow but in others, too, but upon code inspection it resulted the credential issuance flow was the only flow that, upon success, did not reset navigation state, so this change should be a robust solution to the issue.

## List of changes proposed in this pull request

### WLEO-278

The stores that received the `resetLifecycle` listener are the following

- `ts/features/wallet/store`:
  - `credentials.ts`
  - `attestation.ts`
  - `instance.ts`

The other stores have been excluded because they seemed to contain only flow-related state information, that is reset upon flow termination, or because the information they contained was not wallet-related.

### WLEO-301

- `ts/navigation/utils.ts` : added a new `navigateWithReset` function that accepts the same parameters of `navigate` and behaves the same way as the `useNavigateToWalletWithReset` hook (`ts/hooks/useNavigateToWalletWithReset.tsx`) , abstracted the two functions' argument type in a separate one to avoid code duplication.
- `ts/features/wallet/saga/credential.ts` : edited `storeCredentialIdentification` to use the navigation function mentioned above

## How to test

### WLEO-278

1. Obtain a credential and an mDL.
2. Go to the `Settings` screen, enable debug mode and click on _Reset Wallet_.
3. On the main screen, try to scan a presentation QR code for a PID or an mDL, if the credentials have been cleared, none of the presentation should work.
4. Obtain the PID again, and assert that no mDL shows on screen.
5. Obtain the mDL once again.

### WLEO-301

1. Enable debug mode
2. Obtain a PID and an mDL.
3. Go to wallet settings.
4. Reset Wallet
5. A _Success_ toast __should__ appear on screen and __no__ other screen __should__ appear.



[WLEO-301]: https://pagopa.atlassian.net/browse/WLEO-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ