### PR TITLE
fix: [WLEO-301] Solved navigation error upon wallet reset after credential issuance

### DIFF
--- a/ts/features/wallet/saga/credential.ts
+++ b/ts/features/wallet/saga/credential.ts
@@ -20,7 +20,7 @@ import {
   setIdentificationStarted,
   setIdentificationUnidentified
 } from '../../../store/reducers/identification';
-import {navigate} from '../../../navigation/utils';
+import {navigateWithReset} from '../../../navigation/utils';
 import {
   addCredential,
   addCredentialWithIdentification
@@ -245,7 +245,7 @@ function* storeCredentialWithIdentification(
   if (setIdentificationIdentified.match(resAction)) {
     yield* put(addCredential({credential: action.payload.credential}));
     yield* put(resetCredentialIssuance());
-    navigate('MAIN_TAB_NAV');
+    navigateWithReset('MAIN_TAB_NAV');
     IOToast.success(i18next.t('buttons.done', {ns: 'global'}));
   } else {
     return;

--- a/ts/navigation/utils.ts
+++ b/ts/navigation/utils.ts
@@ -6,21 +6,39 @@ import {RootStackParamList} from './RootStacknavigator';
  */
 export const navigationRef = createNavigationContainerRef<RootStackParamList>();
 
-/**
- * Navigate to a screen outside of React context.
- * @param args - The screen name and optional params.
- */
-export function navigate<RouteName extends keyof RootStackParamList>(
-  ...args: RouteName extends unknown
+type NavigationUtilParams<RouteName extends keyof RootStackParamList> =
+  RouteName extends unknown
     ? undefined extends RootStackParamList[RouteName]
       ?
           | [screen: RouteName]
           | [screen: RouteName, params: RootStackParamList[RouteName]]
       : [screen: RouteName, params: RootStackParamList[RouteName]]
-    : never
+    : never;
+
+/**
+ * Navigate to a screen outside of React context.
+ * @param args - The screen name and optional params.
+ */
+export function navigate<RouteName extends keyof RootStackParamList>(
+  ...args: NavigationUtilParams<RouteName>
 ) {
   if (navigationRef.isReady()) {
     navigationRef.navigate(...args);
+  }
+}
+
+/**
+ * Navigate to a screen resetting navigation state outside of React context.
+ * @param args - The screen name and optional params.
+ */
+export function navigateWithReset<RouteName extends keyof RootStackParamList>(
+  ...args: NavigationUtilParams<RouteName>
+) {
+  if (navigationRef.isReady()) {
+    navigationRef.reset({
+      index: 0,
+      routes: [{name: args[0], params: args[1]}]
+    });
   }
 }
 


### PR DESCRIPTION
## Short description

 This PR solves [\[WLEO-301\]](https://pagopa.atlassian.net/jira/software/c/projects/WLEO/boards/601?assignee=712020%3Adcf931c4-2a77-403b-b539-7a018b6d504c&selectedIssue=WLEO-301) by creating a new helper function derived from the `navigate` one in `ts/navigation/utils.ts` that has the same behavior of the `useNavigateToWalletWithReset` hook and that is invoked in `ts/features/wallet/saga/credential.ts.storeCredentialIdentification`.

[\[WLEO-301\]](https://pagopa.atlassian.net/jira/software/c/projects/WLEO/boards/601?assignee=712020%3Adcf931c4-2a77-403b-b539-7a018b6d504c&selectedIssue=WLEO-301)'s description specified that the navigation problem might be present not only inside the credential issuance flow but in others, too, but upon code inspection it resulted the credential issuance flow was the only flow that, upon success, did not reset navigation state, so this change should be a robust solution to the issue.

## List of changes proposed in this pull request

- `ts/navigation/utils.ts` : added a new `navigateWithReset` function that accepts the same parameters of `navigate` and behaves the same way as the `useNavigateToWalletWithReset` hook (`ts/hooks/useNavigateToWalletWithReset.tsx`) , abstracted the two functions' argument type in a separate one to avoid code duplication.
- `ts/features/wallet/saga/credential.ts` : edited `storeCredentialIdentification` to use the navigation function mentioned above

## How to test

1. Enable debug mode
2. Obtain a PID and an mDL.
3. Go to wallet settings.
4. Reset Wallet
5. A _Success_ toast __should__ appear on screen and __no__ other screen __should__ appear.
