### PR TITLE
chore: [WLEO-283] Add debug info to the startup saga

### DIFF
--- a/ts/features/onboarding/utils/biometric.ts
+++ b/ts/features/onboarding/utils/biometric.ts
@@ -5,6 +5,7 @@ import FingerprintScanner, {
   Errors
 } from 'react-native-fingerprint-scanner';
 import {isPinOrFingerprintSet} from 'react-native-device-info';
+import {recordStartupDebugInfo} from '../../../store/utils/debug';
 
 /**
  * Retrieve biometric settings from the base system. This function wraps the basic
@@ -91,25 +92,36 @@ export type BiometricState = 'Available' | 'NotEnrolled' | 'NotSupported';
 
 export const getBiometricState = (): Promise<BiometricState> =>
   new Promise(resolve => {
+    recordStartupDebugInfo({isSensorAvailable: undefined});
     FingerprintScanner.isSensorAvailable()
-      .then(_ => resolve('Available'))
+      .then(_ => {
+        resolve('Available');
+        recordStartupDebugInfo({isSensorAvailable: 'Available'});
+      })
       .catch(e => {
         const error = e as FingerprintScannerError;
         if (error.name === 'FingerprintScannerNotEnrolled') {
           resolve('NotEnrolled');
+          recordStartupDebugInfo({isSensorAvailable: 'NotEnrolled'});
         } else {
           resolve('NotSupported');
+          recordStartupDebugInfo({isSensorAvailable: 'NotSupported'});
         }
       });
   });
 
 export const hasDeviceScreenLock = (): Promise<boolean> =>
   new Promise(resolve => {
+    recordStartupDebugInfo({hasScreenLockFunc: undefined});
     isPinOrFingerprintSet()
       .then(value => {
+        recordStartupDebugInfo({hasScreenLockFunc: value});
         resolve(value);
       })
-      .catch(_ => resolve(false));
+      .catch(_ => {
+        recordStartupDebugInfo({hasScreenLockFunc: false});
+        resolve(false);
+      });
   });
 
 export type BiometriActivationUserType =

--- a/ts/i18n/i18n.ts
+++ b/ts/i18n/i18n.ts
@@ -6,8 +6,13 @@ import enOnboarding from '../../locales/en/onboarding.json';
 import itOnboarding from '../../locales/it/onboarding.json';
 import enWallet from '../../locales/en/wallet.json';
 import enQrCodeScan from '../../locales/en/qrcodeScan.json';
+import {recordStartupDebugInfo} from '../store/utils/debug';
 
-const initI18n = async () =>
+const initI18n = async () => {
+  /*
+   * Debug info to check i18next setup ends correctly
+   */
+  recordStartupDebugInfo({i18nInitialized: false});
   await i18next.use(initReactI18next).init({
     compatibilityJSON: 'v3', // We don't need pluralization
     fallbackLng: 'en',
@@ -28,5 +33,7 @@ const initI18n = async () =>
       }
     }
   });
+  recordStartupDebugInfo({i18nInitialized: true});
+};
 
 export default initI18n;

--- a/ts/i18n/i18n.ts
+++ b/ts/i18n/i18n.ts
@@ -6,13 +6,8 @@ import enOnboarding from '../../locales/en/onboarding.json';
 import itOnboarding from '../../locales/it/onboarding.json';
 import enWallet from '../../locales/en/wallet.json';
 import enQrCodeScan from '../../locales/en/qrcodeScan.json';
-import {recordStartupDebugInfo} from '../store/utils/debug';
 
-const initI18n = async () => {
-  /*
-   * Debug info to check i18next setup ends correctly
-   */
-  recordStartupDebugInfo({i18nInitialized: false});
+const initI18n = async () =>
   await i18next.use(initReactI18next).init({
     compatibilityJSON: 'v3', // We don't need pluralization
     fallbackLng: 'en',
@@ -33,7 +28,5 @@ const initI18n = async () => {
       }
     }
   });
-  recordStartupDebugInfo({i18nInitialized: true});
-};
 
 export default initI18n;

--- a/ts/navigation/RootStacknavigator.tsx
+++ b/ts/navigation/RootStacknavigator.tsx
@@ -17,6 +17,10 @@ import {WalletNavigatorParamsList} from '../features/wallet/navigation/WalletNav
 import LoadingScreenContent from '../components/LoadingScreenContent';
 import {OperationResultScreenContent} from '../components/screens/OperationResultScreenContent';
 import {setUrl} from '../store/reducers/deeplinking';
+import {
+  clearStartupDebugInfo,
+  recordStartupDebugInfo
+} from '../store/utils/debug';
 import {IONavigationDarkTheme, IONavigationLightTheme} from './theme';
 import ROOT_ROUTES from './routes';
 import MainStackNavigator, {
@@ -76,6 +80,20 @@ export const RootStackNavigator = () => {
       />
     );
   };
+
+  /*
+   * Watching isStartupDone because it is used to choose the content to display
+   */
+  useEffect(() => {
+    switch (isStartupDone) {
+      case 'DONE':
+      case 'WAIT_ONBOARDING':
+        clearStartupDebugInfo();
+        break;
+      default:
+        recordStartupDebugInfo({rootStackNavigatorStartupDone: isStartupDone});
+    }
+  }, [isStartupDone]);
 
   useEffect(() => {
     dispatch(startupSetLoading());

--- a/ts/saga/startup.ts
+++ b/ts/saga/startup.ts
@@ -124,7 +124,12 @@ function* startOnboarding() {
  */
 function* startup() {
   try {
+    /*
+    * Debug info to check i18next setup ends correctly
+    */
+    yield* put(sagaRecordStartupDebugInfo({i18nInitialized: false}));
     yield* call(initI18n);
+    yield* put(sagaRecordStartupDebugInfo({i18nInitialized: true}));
     yield* call(checkConfig);
     const biometricState = yield* call(getBiometricState);
     const hasScreenLock = yield* call(hasDeviceScreenLock);

--- a/ts/saga/startup.ts
+++ b/ts/saga/startup.ts
@@ -125,8 +125,8 @@ function* startOnboarding() {
 function* startup() {
   try {
     /*
-    * Debug info to check i18next setup ends correctly
-    */
+     * Debug info to check i18next setup ends correctly
+     */
     yield* put(sagaRecordStartupDebugInfo({i18nInitialized: false}));
     yield* call(initI18n);
     yield* put(sagaRecordStartupDebugInfo({i18nInitialized: true}));

--- a/ts/saga/startup.ts
+++ b/ts/saga/startup.ts
@@ -34,6 +34,7 @@ import {
 import {walletSaga} from '../features/wallet/saga';
 import {selectUrl} from '../store/reducers/deeplinking';
 import {isNavigationReady} from '../navigation/utils';
+import {sagaRecordStartupDebugInfo} from '../store/utils/debug';
 
 function* startIdentification() {
   yield* put(startupSetStatus('WAIT_IDENTIFICATION'));
@@ -43,7 +44,21 @@ function* startIdentification() {
       isValidatingTask: false
     })
   );
+  /*
+   * These debug variable is used to check if the middleware
+   * doesn't block inside BootSplash.hide
+   */
+  yield* put(
+    sagaRecordStartupDebugInfo({
+      startIdentificationBootSplashHideDone: false
+    })
+  );
   yield* call(BootSplash.hide, {fade: true});
+  yield* put(
+    sagaRecordStartupDebugInfo({
+      startIdentificationBootSplashHideDone: true
+    })
+  );
   const action = yield* take([
     setIdentificationIdentified,
     setIdentificationUnidentified
@@ -127,7 +142,21 @@ function* startup() {
     }
   } catch {
     yield* put(startupSetError());
+    /*
+     * These debug variable is used to check if the middleware
+     * doesn't block inside BootSplash.hide
+     */
+    yield* put(
+      sagaRecordStartupDebugInfo({
+        startupCatchSectionBootSplashHideDone: false
+      })
+    );
     yield* call(BootSplash.hide, {fade: true});
+    yield* put(
+      sagaRecordStartupDebugInfo({
+        startupCatchSectionBootSplashHideDone: true
+      })
+    );
   }
 }
 

--- a/ts/saga/startup.ts
+++ b/ts/saga/startup.ts
@@ -45,7 +45,7 @@ function* startIdentification() {
     })
   );
   /*
-   * These debug variable is used to check if the middleware
+   * This debug variable is used to check if the middleware
    * doesn't block inside BootSplash.hide
    */
   yield* put(
@@ -65,7 +65,12 @@ function* startIdentification() {
   ]);
   if (setIdentificationIdentified.match(action)) {
     yield* fork(walletSaga);
+    /*
+     * This debug variable is used to check if the waitForNavigationToBeReady call terminates
+     */
+    yield* put(sagaRecordStartupDebugInfo({isNavigatorReady: false}));
     yield* call(waitForNavigationToBeReady);
+    yield* put(sagaRecordStartupDebugInfo({isNavigatorReady: true}));
     yield* put(startupSetStatus('DONE'));
     yield* call(handlePendingDeepLink);
   } else {

--- a/ts/screens/IdentificationModal.tsx
+++ b/ts/screens/IdentificationModal.tsx
@@ -42,6 +42,7 @@ import {
   selectIsBiometricEnabled
 } from '../store/reducers/preferences';
 import {isAndroid} from '../utils/device';
+import {recordStartupDebugInfo} from '../store/utils/debug';
 
 const onRequestCloseHandler = () => undefined;
 
@@ -161,6 +162,15 @@ const IdentificationModal = () => {
       />
     ) : null
   );
+
+  /*
+   * Watching the status variable because it is responsible for the modal popup
+   */
+  React.useEffect(() => {
+    recordStartupDebugInfo({
+      identificationModalDisplayStatus: status
+    });
+  }, [status]);
 
   // If the authentication process is not started, we don't show the modal.
   // We need to put this before the biometric request,

--- a/ts/store/reducers/debug.ts
+++ b/ts/store/reducers/debug.ts
@@ -18,7 +18,7 @@ type DebugState = Readonly<{
 
 // Initial state for the debug slice
 const initialState: DebugState = {
-  isDebugModeEnabled: false,
+  isDebugModeEnabled: true,
   debugData: {}
 };
 

--- a/ts/store/utils/debug.ts
+++ b/ts/store/utils/debug.ts
@@ -1,0 +1,36 @@
+import {store} from '..';
+import {resetDebugData, setDebugData} from '../reducers/debug';
+
+type StartupDebugInfo = {
+  isSensorAvailable?: string | undefined;
+  hasScreenLockFunc?: unknown;
+  identificationModalDisplayStatus?: string;
+  startIdentificationBootSplashHideDone?: boolean;
+  startupCatchSectionBootSplashHideDone?: boolean;
+  rootStackNavigatorStartupDone?: string;
+  i18nInitialized?: boolean;
+};
+
+const dummyInfo: StartupDebugInfo = {
+  isSensorAvailable: '',
+  hasScreenLockFunc: '',
+  identificationModalDisplayStatus: '',
+  startIdentificationBootSplashHideDone: true,
+  startupCatchSectionBootSplashHideDone: true,
+  rootStackNavigatorStartupDone: '',
+  i18nInitialized: true
+};
+
+const keys = Object.keys(dummyInfo);
+
+export function sagaRecordStartupDebugInfo(fields: StartupDebugInfo) {
+  return setDebugData(fields);
+}
+
+export function recordStartupDebugInfo(fields: StartupDebugInfo) {
+  store.dispatch(setDebugData(fields));
+}
+
+export function clearStartupDebugInfo() {
+  store.dispatch(resetDebugData(keys));
+}

--- a/ts/store/utils/debug.ts
+++ b/ts/store/utils/debug.ts
@@ -34,17 +34,21 @@ type StartupDebugInfo = {
    */
   identificationModalDisplayStatus?: string;
   /**
-   * This variable tracks the temination status of the {@link BootSplash\.hide} library method invocation
-   * inside of the startIdentification subsaga.
+   * This variable tracks the termination status of the {@link BootSplash\.hide} library method invocation
+   * inside of the {@link startIdentification} subsaga.
    */
   startIdentificationBootSplashHideDone?: boolean;
   /**
-   * This variable tracks the temination status of the {@link BootSplash\.hide} library method invocation
+   * This variable tracks the termination status of the {@link BootSplash\.hide} library method invocation
    * inside of the catch segment of the startup saga.
    */
   startupCatchSectionBootSplashHideDone?: boolean;
   /**
-   * This variable tracks the status varuable used in the {@link RootStackNavigator} to
+   * This variable tracks the termination status of the {@link waitForNavigationToBeReady} function call in the startup saga.
+   */
+  isNavigatorReady?: boolean;
+  /**
+   * This variable tracks the status variable used in the {@link RootStackNavigator} to
    * choose what should be displayed on screen (if the loading screen, an error screen or the main navigatior).
    */
   rootStackNavigatorStartupDone?: string;
@@ -58,7 +62,7 @@ type StartupDebugInfo = {
 /**
  * This dummyInfo variable is used to extract a list of the keys of the {@link StartupDebugInfo} type
  * that will be used to clear all the variables watched when not needed anymore.
- * In order to make thi swork correctly, it is necessary to add an entry to this object for every
+ * In order to make this work correctly, it is necessary to add an entry to this object for every
  * entry declared in {@link StartupDebugInfo}, even if it has been declared as optional.
  */
 const dummyInfo: StartupDebugInfo = {
@@ -68,7 +72,8 @@ const dummyInfo: StartupDebugInfo = {
   startIdentificationBootSplashHideDone: true,
   startupCatchSectionBootSplashHideDone: true,
   rootStackNavigatorStartupDone: '',
-  i18nInitialized: true
+  i18nInitialized: true,
+  isNavigatorReady: false
 };
 
 const keys = Object.keys(dummyInfo);
@@ -76,7 +81,7 @@ const keys = Object.keys(dummyInfo);
 /**
  * Method to add entries of {@link StartupDebugInfo} to the debug watcher to be used inside of sagas.
  * @param fields a subset of the entries of the {@link StartupDebugInfo} type containing variables to be watched
- * @returns An action to be dispatched by the saga by the {@link put} mehtod.
+ * @returns An action to be dispatched by the saga by the {@link put} method.
  */
 export function sagaRecordStartupDebugInfo(fields: StartupDebugInfo) {
   return setDebugData(fields);
@@ -93,7 +98,6 @@ export function recordStartupDebugInfo(fields: StartupDebugInfo) {
 
 /**
  * Method to clear all entries entries of {@link StartupDebugInfo} from the debug watcher.
- * hook is not available.
  */
 export function clearStartupDebugInfo() {
   store.dispatch(resetDebugData(keys));

--- a/ts/store/utils/debug.ts
+++ b/ts/store/utils/debug.ts
@@ -9,10 +9,9 @@ import {resetDebugData, setDebugData} from '../reducers/debug';
  * and, as a consequence, all variables are correctly removed
  */
 
-
 /*
-*************************** TYPES FOR CAPTURING STARTUP SAGA DEBUG INFO *****************************
-*/
+ *************************** TYPES FOR CAPTURING STARTUP SAGA DEBUG INFO *****************************
+ */
 
 /**
  * Type that acts as a registry of all the variables a user wants to monitor

--- a/ts/store/utils/debug.ts
+++ b/ts/store/utils/debug.ts
@@ -1,16 +1,67 @@
 import {store} from '..';
 import {resetDebugData, setDebugData} from '../reducers/debug';
 
+/**
+ * The purpose of this module is to add stronger typing to the debugging of sagas: being that
+ * the collection of debug info must happen across the sagas, but such info's removal happens
+ * in a single point, by registering every debug variable one wants to add in the types above
+ * and using the helper methods here defined, it is ensured that every variable is tracked down
+ * and, as a consequence, all variables are correctly removed
+ */
+
+
+/*
+*************************** TYPES FOR CAPTURING STARTUP SAGA DEBUG INFO *****************************
+*/
+
+/**
+ * Type that acts as a registry of all the variables a user wants to monitor
+ * Every new variable should be added to this type to enforce a stronger control on serializaiton
+ */
 type StartupDebugInfo = {
+  /**
+   * This variable tracks the status of the {@link getBiometricsType} util method.
+   * It captures whether or not the promise has been resolved and the resolution value.
+   */
   isSensorAvailable?: string | undefined;
+  /**
+   * This variable tracks the status of the {@link hasDeviceScreenLock} util method.
+   * It captures whether or not the promise has been resolved and the resolution value.
+   */
   hasScreenLockFunc?: unknown;
+  /**
+   * This variable tracks the identification status used in the {@link IdentificationModal} to
+   * choose whether to display the identificaiton modal or not.
+   */
   identificationModalDisplayStatus?: string;
+  /**
+   * This variable tracks the temination status of the {@link BootSplash\.hide} library method invocation
+   * inside of the startIdentification subsaga.
+   */
   startIdentificationBootSplashHideDone?: boolean;
+  /**
+   * This variable tracks the temination status of the {@link BootSplash\.hide} library method invocation
+   * inside of the catch segment of the startup saga.
+   */
   startupCatchSectionBootSplashHideDone?: boolean;
+  /**
+   * This variable tracks the status varuable used in the {@link RootStackNavigator} to
+   * choose what should be displayed on screen (if the loading screen, an error screen or the main navigatior).
+   */
   rootStackNavigatorStartupDone?: string;
+  /**
+   * This variable tracks the status of the {@link initI18n} util method.
+   * It captures whether or not the promise has been resolved.
+   */
   i18nInitialized?: boolean;
 };
 
+/**
+ * This dummyInfo variable is used to extract a list of the keys of the {@link StartupDebugInfo} type
+ * that will be used to clear all the variables watched when not needed anymore.
+ * In order to make thi swork correctly, it is necessary to add an entry to this object for every
+ * entry declared in {@link StartupDebugInfo}, even if it has been declared as optional.
+ */
 const dummyInfo: StartupDebugInfo = {
   isSensorAvailable: '',
   hasScreenLockFunc: '',
@@ -23,14 +74,28 @@ const dummyInfo: StartupDebugInfo = {
 
 const keys = Object.keys(dummyInfo);
 
+/**
+ * Method to add entries of {@link StartupDebugInfo} to the debug watcher to be used inside of sagas.
+ * @param fields a subset of the entries of the {@link StartupDebugInfo} type containing variables to be watched
+ * @returns An action to be dispatched by the saga by the {@link put} mehtod.
+ */
 export function sagaRecordStartupDebugInfo(fields: StartupDebugInfo) {
   return setDebugData(fields);
 }
 
+/**
+ * Method to add entries of {@link StartupDebugInfo} to the debug watcher to be used when the {@link useAppDispatch}
+ * hook is not available.
+ * @param fields a subset of the entries of the {@link StartupDebugInfo} type containing variables to be watched
+ */
 export function recordStartupDebugInfo(fields: StartupDebugInfo) {
   store.dispatch(setDebugData(fields));
 }
 
+/**
+ * Method to clear all entries entries of {@link StartupDebugInfo} from the debug watcher.
+ * hook is not available.
+ */
 export function clearStartupDebugInfo() {
   store.dispatch(resetDebugData(keys));
 }


### PR DESCRIPTION
## Short description

In order to spot what causes the loading issue, various debug guards have been added to monitor the state of the startup saga.

## List of changes proposed in this pull request

- `ts/store/reducers/debug.ts` : set debug mode enabled by default, being that the loading issue blocks the application and makes it impossible to set the mode on.

- `ts/store/utils/debug.ts` : being that debug information is collected across different parts of the code, some helper methods have been introduced: these are basically wrappers of the basic dispatch of the `setDebugData` action that enforce a stricter typing, this way clearing all debug data reduces to a `clearStartupDebugInfo` invocation.

- `ts/features/onboarding/utils.ts` : captured debug info to monitor the state of the promises launched in `getBiometricState` and `hasDeviceScreenLock`.

- `ts/i18n/i18n.ts` : Added debug guards to monitor `i18n` setup state.

- `ts/navigation/RootStackNavigatior.tsx` : captured debug info for the `isStartupDone` variable, which rules the navigation, and is a reset point for the debug state.

- `ts/saga/startup.ts` : Added collection of debug info for the invocation of the `BootSplash.hide` function.

- `ts/screens/IdentificationModal.tsx` : Added recording of the status value that decides whether the modal should render or not, in case the flow goes well but the modal doesn't trigger.

## How to test

Check that, when the initial loading screen appears, some debug messages are present. Optionally, comment out the `clearStartupDebugInfo` invocation in  `ts/navigation/RootStackNavigatior.tsx` and check that the debug variables are present when the navigation arrives at the wallet main screen.
