### PR TITLE
feat: [WLEO-368] Added possibility to uncheck required data for RP remote presentations

### DIFF
--- a/ts/features/wallet/components/presentation/PresentationClaimsList.tsx
+++ b/ts/features/wallet/components/presentation/PresentationClaimsList.tsx
@@ -11,7 +11,11 @@ import {StyleSheet, View} from 'react-native';
 import React from 'react';
 import i18next from 'i18next';
 import {useTranslation} from 'react-i18next';
-import {Descriptor, OptionalClaimsNames} from '../../store/presentation';
+import {
+  Descriptor,
+  OptionalClaimsNames,
+  RequiredClaimsNames
+} from '../../store/presentation';
 import {ClaimDisplayFormat} from '../../utils/types';
 import {getSafeText, isStringNullyOrEmpty} from '../../../../utils/string';
 import {claimScheme, VerificationEvidenceType} from '../../utils/claims';
@@ -19,6 +23,8 @@ import {claimScheme, VerificationEvidenceType} from '../../utils/claims';
 export type RequiredClaimsProps = {
   optionalChecked: Array<OptionalClaimsNames>;
   setOptionalChecked: (encoded: OptionalClaimsNames) => void;
+  requiredExcluded?: Array<RequiredClaimsNames>;
+  setRequiredExcluded?: (encoded: RequiredClaimsNames) => void;
   descriptor: Descriptor;
   source: string;
 };
@@ -34,7 +40,9 @@ const PresentationClaimsList = ({
   descriptor,
   source,
   optionalChecked,
-  setOptionalChecked
+  setOptionalChecked,
+  requiredExcluded = undefined,
+  setRequiredExcluded = undefined
 }: RequiredClaimsProps) => {
   const requiredDisclosures = descriptor.flatMap(
     item => item.evaluatedDisclosure.requiredDisclosures
@@ -72,7 +80,14 @@ const PresentationClaimsList = ({
                       {source}
                     </BodySmall>
                   </View>
-                  <AnimatedCheckbox checked={true} />
+                  {requiredExcluded && setRequiredExcluded ? (
+                    <AnimatedCheckbox
+                      checked={!requiredExcluded.includes(claim.name)}
+                      onPress={_ => setRequiredExcluded(claim.name)}
+                    />
+                  ) : (
+                    <AnimatedCheckbox checked={true} />
+                  )}
                 </View>
               </View>
             ))}

--- a/ts/features/wallet/saga/presentation.ts
+++ b/ts/features/wallet/saga/presentation.ts
@@ -103,7 +103,12 @@ function* handlePresetationPreDefinition(
     ]);
 
     if (setPostDefinitionRequest.match(choice)) {
-      const {payload: optionalClaimsNames} = choice;
+      const {
+        payload: {
+          optionalChecked: optionalClaimsNames,
+          requiredExcluded: excludedRequiredClaimsNames
+        }
+      } = choice;
       yield* put(
         setIdentificationStarted({canResetPin: false, isValidatingTask: true})
       );
@@ -117,9 +122,13 @@ function* handlePresetationPreDefinition(
         const credentialAndInputDescriptor = evaluateInputDescriptors.map(
           evaluateInputDescriptor => {
             const requestedClaims = [
-              ...evaluateInputDescriptor.evaluatedDisclosure.requiredDisclosures.map(
-                item => item.name
-              ),
+              ...(excludedRequiredClaimsNames
+                ? evaluateInputDescriptor.evaluatedDisclosure.requiredDisclosures.filter(
+                    item => !excludedRequiredClaimsNames.includes(item.name)
+                  )
+                : evaluateInputDescriptor.evaluatedDisclosure
+                    .requiredDisclosures
+              ).map(item => item.name),
               ...optionalClaimsNames
             ];
             return {

--- a/ts/features/wallet/screens/presentation/PresentationPostDefinition.tsx
+++ b/ts/features/wallet/screens/presentation/PresentationPostDefinition.tsx
@@ -56,6 +56,7 @@ const PresentationPostDefinition = ({route}: Props) => {
   const postDefinitionStatus = useAppSelector(selectPostDefinitionStatus);
   const {navigateToWallet} = useNavigateToWalletWithReset();
   const [optionalChecked, setOptionalChecked] = useState([] as Array<string>);
+  const [requiredExcluded, setRequiredExcluded] = useState([] as Array<string>);
 
   // Disable the back gesture navigation and the hardware back button
   useDisableGestureNavigation();
@@ -78,6 +79,19 @@ const PresentationPostDefinition = ({route}: Props) => {
         style: 'cancel'
       }
     ]);
+  };
+
+  /**
+   * Callback for when the user checks or unchecks a required disclosure
+   * in the PresentationClaimsList component.
+   * @param encoded - The encoded string of the required disclosure
+   */
+  const onRequiredDisclosuresChange = (encoded: OptionalClaimsNames) => {
+    if (requiredExcluded.includes(encoded)) {
+      setRequiredExcluded(requiredExcluded.filter(item => item !== encoded));
+    } else {
+      setRequiredExcluded([...requiredExcluded, encoded]);
+    }
   };
 
   /**
@@ -136,6 +150,8 @@ const PresentationPostDefinition = ({route}: Props) => {
         <PresentationClaimsList
           optionalChecked={optionalChecked}
           setOptionalChecked={onOptionalDisclosuresChange}
+          requiredExcluded={requiredExcluded}
+          setRequiredExcluded={onRequiredDisclosuresChange}
           descriptor={route.params.descriptor}
           source={getCredentialNameByType(wellKnownCredential.PID)}
         />
@@ -156,7 +172,10 @@ const PresentationPostDefinition = ({route}: Props) => {
           type: 'TwoButtons',
           primary: {
             label: t('global:buttons.confirm'),
-            onPress: () => dispatch(setPostDefinitionRequest(optionalChecked)),
+            onPress: () =>
+              dispatch(
+                setPostDefinitionRequest({optionalChecked, requiredExcluded})
+              ),
             loading: postDefinitionStatus.loading
           },
           secondary: {

--- a/ts/features/wallet/store/presentation.ts
+++ b/ts/features/wallet/store/presentation.ts
@@ -38,6 +38,12 @@ export type AuthResponse = Awaited<
 export type OptionalClaimsNames =
   Descriptor[0]['evaluatedDisclosure']['optionalDisclosures'][0]['name']; // Name of the optional claims selected by the user
 
+/**
+ * Type of the required claims names selected by the user.
+ */
+export type RequiredClaimsNames =
+  Descriptor[0]['evaluatedDisclosure']['requiredDisclosures'][0]['name']; // Name of the required claims selected by the user
+
 /* State type definition for the presentation slice
  * preDefinition - Async status for the prestation before receiving the descriptor
  * postDefinition - Async status for the presentation afetr receiving the descriptor
@@ -74,7 +80,10 @@ export const presentationSlice = createSlice({
     },
     setPostDefinitionRequest: (
       state,
-      _: PayloadAction<Array<OptionalClaimsNames>>
+      _: PayloadAction<{
+        optionalChecked: Array<OptionalClaimsNames>;
+        requiredExcluded?: Array<RequiredClaimsNames>;
+      }>
     ) => {
       /* Payload is not used but taken from the saga
        * The payload is an array of strings containing the optional claims selected by the user


### PR DESCRIPTION
## Short description

This PR adds functionality to uncheck required data during remote presentations.

## List of changes proposed in this pull request

- `ts/features/wallet/store/presentation.ts` : Created and exported the type `RequiredClaimsNames` and changed setPostDefinitionRequest action's signature to accept an optional `requiredExcluded` field.

- `ts/features/wallet/components/presentation/PresentationClaimsList.tsx` : Added optional props `requiredExcluded` and `setRequiredExcluded` that, when passed, provide to the required claims section functionality similar to the optional one, the only difference is that the selection state is based on the absence of the attribute from the list instead of its presence.

- `ts/features/wallet/saga/presentation.ts` : Added filtering of the excluded required claims names, if present.

`-ts/features/wallet/screen/presentation/PresentationPostDefinition.tsx` : Linked new functionalities.

Note: The newly declared attributes have been made optional to keep other code that doesn't want the new functionalities untouched.

## How to test

1. Obtain a driving license: when presented with the trust screen showing the required PID claims, **no** field **should** be uncheckable.
2. Prepare a remote presentation with an RP that requests some optional data:
    1. Check that **both** the required and optional data **are** checkable/uncheckable.
    2. Unselect some required attributes and select some of the optional ones: check that **only** the selected data has been presented to the RP.