### PR TITLE
chore: [WLEO-397] Add URL wildcard intent Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,14 @@
   <!-- Required by react-native-vision-camera -->
   <uses-permission android:name="android.permission.CAMERA" />
 
+   <!-- Required to open URL after a remote presentation flow on some devices -->
+  <queries>
+      <intent>
+          <action android:name="android.intent.action.VIEW" />
+          <data android:scheme="https" android:host="*" />
+      </intent>
+  </queries>
+
   <application
     android:name=".MainApplication"
     android:label="@string/app_name"
@@ -69,5 +77,7 @@
         android:name="photopicker_activity:0:required"
         android:value="" />
     </service>
+
+   
   </application>
 </manifest>

--- a/locales/en/global.json
+++ b/locales/en/global.json
@@ -73,10 +73,7 @@
     }
   },
   "errors": {
-    "generic": {
-      "title": "There's an issue with our systems",
-      "body": "Please try again in a few minutes."
-    }
+    "generic": "An error occurred"
   },
   "cancelOperation": {
     "title": "Do you want to stop the operation?",

--- a/ts/components/markdown/renderRules.tsx
+++ b/ts/components/markdown/renderRules.tsx
@@ -180,7 +180,7 @@ export const DEFAULT_RULES: IOMarkdownRenderRules = {
   Link(link: TxtLinkNode, render: Renderer) {
     const handleOpenLink = () => {
       openWebUrl(link.url, () => {
-        IOToast.error(i18next.t('errors.generic.title', {ns: 'global'}));
+        IOToast.error(i18next.t('errors.generic', {ns: 'global'}));
       });
     };
 

--- a/ts/features/wallet/screens/presentation/PresentationSuccess.tsx
+++ b/ts/features/wallet/screens/presentation/PresentationSuccess.tsx
@@ -39,7 +39,7 @@ const PresentationSuccess = () => {
             label: t('global:buttons.continue'),
             onPress: () => {
               openWebUrl(redirectUri, () =>
-                toast.success(t('global:errors.generic.title'))
+                toast.error(t('global:errors.generic'))
               );
               navigateToWallet();
               dispatch(resetPresentation());

--- a/ts/i18n/types/resources.d.ts
+++ b/ts/i18n/types/resources.d.ts
@@ -74,10 +74,7 @@ interface Resources {
       }
     },
     "errors": {
-      "generic": {
-        "title": "There's an issue with our systems",
-        "body": "Please try again in a few minutes."
-      }
+      "generic": "An error occurred"
     },
     "cancelOperation": {
       "title": "Do you want to stop the operation?",


### PR DESCRIPTION
## Short description
This PR adds the intent to open `https` urls with the `hosts` wildcard in order to open the provided URL, if any, after a presentation flow.
## List of changes proposed in this pull request

- Update the `AndroidManifest` with the required intent;
- Update the toast type which was `success` instead of `error` if the URL can't be opened;
- Update the generic message locale string.

## How to test
Test a presentation flow which provides a `redirect_uri` at the end of the flow. The browser should be opened.
