### PR TITLE
fix: [WLEO-460] Add WIA expiration check

### DIFF
--- a/ts/features/wallet/saga/attestation.ts
+++ b/ts/features/wallet/saga/attestation.ts
@@ -1,4 +1,4 @@
-import {call, select} from 'typed-redux-saga';
+import {call, put, select} from 'typed-redux-saga';
 import Config from 'react-native-config';
 import {
   createCryptoContextFor,
@@ -9,32 +9,52 @@ import {WIA_KEYTAG} from '../utils/crypto';
 import {getIntegrityContext} from '../utils/integrity';
 import {createWalletProviderFetch} from '../utils/fetch';
 import {selectSessionId} from '../../../store/reducers/preferences';
+import {selectInstanceKeyTag} from '../store/instance';
+import {selectAttestation, setAttestation} from '../store/attestation';
+import {isWalletInstanceAttestationValid} from '../utils/attestation';
 
 /**
- * Utility generator function to obtain a wallet attestation.
- * @param instanceKeyTag - the keytag bound to the wallet instance for which the attestation is requested.
- * @returns the attestation for the wallet instance.
- * @throws {@link Errors.WalletProviderResponseError} if the wallet provider returns an error.
+ * Utility generator function to obtain a wallet attestation and set it in the store.
+ * @returns the existing or newly generated Wallet Instance Attestation.
  */
-export function* getAttestation(instanceKeyTag: string) {
-  const sessionId = yield* select(selectSessionId);
-  const walletProviderBaseUrl = Config.WALLET_PROVIDER_BASE_URL;
-  const appFetch = createWalletProviderFetch(walletProviderBaseUrl, sessionId);
+export function* getAttestation() {
+  const instanceKeyTag = yield* select(selectInstanceKeyTag);
+  if (!instanceKeyTag) {
+    throw new Error('Instance key tag is not set. Cannot obtain attestation.');
+  }
+  // If we don't have an existing attestation or it's not valid, we need to generate a new one.
+  const existingAttestation = yield* select(selectAttestation);
+  if (
+    !existingAttestation ||
+    !isWalletInstanceAttestationValid(existingAttestation)
+  ) {
+    const sessionId = yield* select(selectSessionId);
+    const walletProviderBaseUrl = Config.WALLET_PROVIDER_BASE_URL;
+    const appFetch = createWalletProviderFetch(
+      walletProviderBaseUrl,
+      sessionId
+    );
 
-  const integrityContext = getIntegrityContext(instanceKeyTag);
-  // generate Key for Wallet Instance Attestation
-  // ensure the key esists befor starting the issuing process
-  yield* call(regenerateCryptoKey, WIA_KEYTAG);
-  const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
+    const integrityContext = getIntegrityContext(instanceKeyTag);
+    // generate Key for Wallet Instance Attestation
+    // ensure the key esists befor starting the issuing process
+    yield* call(regenerateCryptoKey, WIA_KEYTAG);
+    const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
 
-  /**
-   * Obtains a new Wallet Instance Attestation.
-   * WARNING: The integrity context must be the same used when creating the Wallet Instance with the same keytag.
-   */
-  return yield* call(WalletInstanceAttestation.getAttestation, {
-    wiaCryptoContext,
-    integrityContext,
-    walletProviderBaseUrl,
-    appFetch
-  });
+    /**
+     * Obtains a new Wallet Instance Attestation.
+     * WARNING: The integrity context must be the same used when creating the Wallet Instance with the same keytag.
+     */
+    const attestation = yield* call(WalletInstanceAttestation.getAttestation, {
+      wiaCryptoContext,
+      integrityContext,
+      walletProviderBaseUrl,
+      appFetch
+    });
+
+    yield* put(setAttestation(attestation));
+    return attestation;
+  } else {
+    return existingAttestation;
+  }
 }

--- a/ts/features/wallet/saga/credential.ts
+++ b/ts/features/wallet/saga/credential.ts
@@ -14,7 +14,6 @@ import {
 } from '@pagopa/io-react-native-login-utils';
 import {regenerateCryptoKey} from '../../../utils/crypto';
 import {DPOP_KEYTAG} from '../utils/crypto';
-import {selectAttestation} from '../store/attestation';
 import {
   setIdentificationIdentified,
   setIdentificationStarted,
@@ -35,6 +34,7 @@ import {
   setCredentialIssuancePreAuthRequest,
   setCredentialIssuancePreAuthSuccess
 } from '../store/credentialIssuance';
+import {getAttestation} from './attestation';
 
 /**
  * Saga watcher for credential related actions.
@@ -71,14 +71,8 @@ function* obtainCredential() {
       throw new Error('Credential type not found');
     }
 
-    /**
-     * Get the wallet instance attestation from the store and throw an error if it's not found.
-     * Also generate its cryptocontext.
-     */
-    const walletInstanceAttestation = yield* select(selectAttestation);
-    if (!walletInstanceAttestation) {
-      throw new Error('Wallet instance attestation not found');
-    }
+    // Get the wallet instance attestation and generate its crypto context
+    const walletInstanceAttestation = yield* call(getAttestation);
     const wiaCryptoContext = createCryptoContextFor('WIA_KEYTAG');
 
     // Create credential crypto context

--- a/ts/features/wallet/saga/instance.ts
+++ b/ts/features/wallet/saga/instance.ts
@@ -1,12 +1,11 @@
 import {call, put, race, select, take, takeLatest} from 'typed-redux-saga';
 import Config from 'react-native-config';
-import {Errors, WalletInstance} from '@pagopa/io-react-native-wallet';
+import {WalletInstance} from '@pagopa/io-react-native-wallet';
 import {serializeError} from 'serialize-error';
 import {
   generateIntegrityHardwareKeyTag,
   getIntegrityContext
 } from '../utils/integrity';
-import {setAttestation} from '../store/attestation';
 import {selectSessionId} from '../../../store/reducers/preferences';
 import {selectInstanceKeyTag, setInstanceKeyTag} from '../store/instance';
 import {createWalletProviderFetch} from '../utils/fetch';
@@ -17,7 +16,6 @@ import {
   setInstanceCreationSuccess
 } from '../store/pidIssuance';
 import {resetCredentials} from '../store/credentials';
-import {getAttestation} from './attestation';
 
 export function* watchInstanceSaga() {
   yield* takeLatest([setInstanceCreationRequest], function* (...args) {
@@ -30,64 +28,34 @@ export function* watchInstanceSaga() {
 
 /**
  * Saga which handles the creation of a wallet instance.
- * If a wallet instance already exists, it will use the existing instance key tag.
- * It then fetches a wallet attestation to check if the instance is valid.
- * If the attestation is valid then it is set in the store.
- * However, if the attestation returns an error which indicates that the instance has been revoked (403) or not found (404),
- * then it will create a new instance and obtain a new attestation.
- * If a wallet instance doesn't exists then it will create a new instance and obtain a new attestation.
+ * If a wallet instance already exists this will be skipped.
+ * There's no revokation mechanism at the moment, so this doesn't get checked.
  */
 export function* handleCreateInstance() {
   try {
-    const existingInstanceKeyTag = yield* select(selectInstanceKeyTag);
+    const instanceKeyTag = yield* select(selectInstanceKeyTag);
 
-    if (existingInstanceKeyTag) {
-      // Instance exists, try to get an attestation
-      try {
-        const attestation = yield* call(getAttestation, existingInstanceKeyTag);
-        yield* put(setAttestation(attestation));
-        yield* put(setInstanceCreationSuccess());
-        return;
-      } catch (e) {
-        // An error occurred while obtaining an attestation
-        const err = e as Errors.WalletProviderResponseError;
-        if (
-          err.code !== 'ERR_IO_WALLET_INSTANCE_REVOKED' &&
-          err.code !== 'ERR_IO_WALLET_INSTANCE_NOT_FOUND'
-        ) {
-          // If the error is not related to the instance being revoked or not found, re-throw the error
-          throw err;
-        }
-      }
+    if (!instanceKeyTag) {
+      const walletProviderBaseUrl = Config.WALLET_PROVIDER_BASE_URL;
+      const sessionId = yield* select(selectSessionId);
+      const appFetch = createWalletProviderFetch(
+        walletProviderBaseUrl,
+        sessionId
+      );
+      const keyTag = yield* call(generateIntegrityHardwareKeyTag);
+      const integrityContext = getIntegrityContext(keyTag);
+
+      yield* call(WalletInstance.createWalletInstance, {
+        integrityContext,
+        walletProviderBaseUrl,
+        appFetch
+      });
+      yield* put(setInstanceKeyTag(keyTag));
+      yield* put(setInstanceCreationSuccess());
+      // Reset the credential state before obtaining a new PID
+      yield* put(resetCredentials());
     }
-    // Create a new instance if none exists or the existing instance is revoked or not found
-    const keyTag = yield* call(createInstance);
-    const attestation = yield* call(getAttestation, keyTag);
-    yield* put(setInstanceKeyTag(keyTag));
-    yield* put(setAttestation(attestation));
-    yield* put(setInstanceCreationSuccess());
-    // Reset the credential state before obtaining a new PID
-    yield* put(resetCredentials());
   } catch (err: unknown) {
     yield* put(setInstanceCreationError({error: serializeError(err)}));
   }
-}
-
-/**
- * Utility generator function to create a new wallet instance.
- * @returns the keytag used to create the wallet instance.
- */
-export function* createInstance() {
-  const walletProviderBaseUrl = Config.WALLET_PROVIDER_BASE_URL;
-  const sessionId = yield* select(selectSessionId);
-  const appFetch = createWalletProviderFetch(walletProviderBaseUrl, sessionId);
-  const keyTag = yield* call(generateIntegrityHardwareKeyTag);
-  const integrityContext = getIntegrityContext(keyTag);
-
-  yield* call(WalletInstance.createWalletInstance, {
-    integrityContext,
-    walletProviderBaseUrl,
-    appFetch
-  });
-  return keyTag;
 }

--- a/ts/features/wallet/saga/pid.ts
+++ b/ts/features/wallet/saga/pid.ts
@@ -7,13 +7,12 @@ import {
   Credential
 } from '@pagopa/io-react-native-wallet';
 import Config from 'react-native-config';
-import {call, put, select, take, takeLatest} from 'typed-redux-saga';
+import {call, put, take, takeLatest} from 'typed-redux-saga';
 import uuid from 'react-native-uuid';
 import {generate} from '@pagopa/io-react-native-crypto';
 import {serializeError} from 'serialize-error';
 import {regenerateCryptoKey} from '../../../utils/crypto';
 import {DPOP_KEYTAG} from '../utils/crypto';
-import {selectAttestation} from '../store/attestation';
 import {
   setPidIssuanceError,
   setPidIssuanceRequest,
@@ -28,6 +27,7 @@ import {Lifecycle, setLifecycle} from '../store/lifecycle';
 import {navigate} from '../../../navigation/utils';
 import {addCredential, addPidWithIdentification} from '../store/credentials';
 import {wellKnownCredential} from '../utils/credentials';
+import {getAttestation} from './attestation';
 
 /**
  * Saga watcher for PID related actions.
@@ -46,12 +46,8 @@ function* obtainPid() {
   try {
     const {PID_PROVIDER_BASE_URL, PID_REDIRECT_URI: redirectUri} = Config;
 
-    const walletInstanceAttestation = yield* select(selectAttestation);
-
-    if (!walletInstanceAttestation) {
-      throw new Error('Wallet instance attestation not found');
-    }
-
+    // Get the wallet instance attestation and generate its crypto context
+    const walletInstanceAttestation = yield* call(getAttestation);
     const wiaCryptoContext = createCryptoContextFor('WIA_KEYTAG');
 
     // Start the issuance flow

--- a/ts/features/wallet/saga/presentation.ts
+++ b/ts/features/wallet/saga/presentation.ts
@@ -11,7 +11,6 @@ import {
   setPreDefinitionError,
   setPreDefinitionRequest
 } from '../store/presentation';
-import {selectAttestation} from '../store/attestation';
 import {selectCredentials} from '../store/credentials';
 import {
   setIdentificationIdentified,
@@ -33,7 +32,7 @@ import {
  * Saga watcher for presentation related actions.
  */
 export function* watchPresentationSaga() {
-  yield* takeLatest(setPreDefinitionRequest, handlePresetationPreDefinition);
+  yield* takeLatest(setPreDefinitionRequest, handlePresentationPreDefinition);
 }
 
 /**
@@ -43,15 +42,10 @@ export function* watchPresentationSaga() {
  * - Pre-definition: the app asks for the required claims to be presented to the RP;
  * - Post-definition: the app sends the required claims to the RP after identification.
  */
-function* handlePresetationPreDefinition(
+function* handlePresentationPreDefinition(
   action: ReturnType<typeof setPreDefinitionRequest>
 ) {
   try {
-    // Gets the Wallet Instance Attestation from the persisted store
-    const walletInstanceAttestation = yield* select(selectAttestation);
-    if (!walletInstanceAttestation) {
-      throw new Error('Wallet Instance Attestation not found');
-    }
     const {request_uri, client_id} = action.payload;
 
     const {requestUri} = yield* call(

--- a/ts/features/wallet/store/index.ts
+++ b/ts/features/wallet/store/index.ts
@@ -1,6 +1,4 @@
 import {combineReducers} from '@reduxjs/toolkit';
-import {PersistConfig, persistReducer} from 'redux-persist';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import {PersistPartial} from 'redux-persist/es/persistReducer';
 import {lifecycleReducer, LifecycleState} from './lifecycle';
 import {attestationReducer, AttestationState} from './attestation';
@@ -15,8 +13,8 @@ import {PresentationState, presentationReducer} from './presentation';
 import {proximityReducer, ProximityState} from './proximity';
 
 export type WalletState = {
-  lifecycle: LifecycleState;
-  instance: InstanceState;
+  lifecycle: LifecycleState & PersistPartial;
+  instance: InstanceState & PersistPartial;
   attestation: AttestationState & PersistPartial;
   pidIssuanceStatus: PidIssuanceStatusState;
   credentials: CredentialsState & PersistPartial;
@@ -36,12 +34,4 @@ const walletReducer = combineReducers({
   proximity: proximityReducer
 });
 
-const itwPersistConfig: PersistConfig<WalletState> = {
-  key: 'itWallet',
-  storage: AsyncStorage,
-  whitelist: ['lifecycle'] satisfies Array<keyof WalletState>
-};
-
-export const persistedReducer = persistReducer(itwPersistConfig, walletReducer);
-
-export default persistedReducer;
+export default walletReducer;

--- a/ts/features/wallet/store/instance.ts
+++ b/ts/features/wallet/store/instance.ts
@@ -1,5 +1,7 @@
 /* eslint-disable functional/immutable-data */
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {PersistConfig, persistReducer} from 'redux-persist';
 import {RootState} from '../../../store/types';
 import {preferencesReset} from '../../../store/reducers/preferences';
 import {resetLifecycle} from './lifecycle';
@@ -37,11 +39,26 @@ const instanceSlice = createSlice({
 });
 
 /**
+ * Redux persist configuration for the instance slice.
+ * Currently it uses AsyncStorage as the storage engine.
+ */
+const instancePersist: PersistConfig<InstanceState> = {
+  key: 'attestation',
+  storage: AsyncStorage
+};
+
+/**
+ * Persisted reducer for the instance slice.
+ */
+export const instanceReducer = persistReducer(
+  instancePersist,
+  instanceSlice.reducer
+);
+
+/**
  * Exports the actions for the instance slice.
  */
 export const {setInstanceKeyTag, resetInstanceKeyTag} = instanceSlice.actions;
-
-export const {reducer: instanceReducer} = instanceSlice;
 
 /**
  * Select the wallet instance keytag.

--- a/ts/features/wallet/store/lifecycle.ts
+++ b/ts/features/wallet/store/lifecycle.ts
@@ -1,5 +1,7 @@
 /* eslint-disable functional/immutable-data */
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {PersistConfig, persistReducer} from 'redux-persist';
 import {RootState} from '../../../store/types';
 import {preferencesReset} from '../../../store/reducers/preferences';
 import {wellKnownCredential} from '../utils/credentials';
@@ -12,8 +14,8 @@ import {removeCredential} from './credentials';
  * LIFECYCLE_DEACTIVATED - The wallet is deactivated (not used).
  */
 export enum Lifecycle {
-  'LIFECYCLE_VALID',
   'LIFECYCLE_OPERATIONAL',
+  'LIFECYCLE_VALID',
   'LIFECYCLE_DEACTIVATED'
 }
 
@@ -53,11 +55,26 @@ const lifecycleSlice = createSlice({
 });
 
 /**
+ * Redux persist configuration for the instance slice.
+ * Currently it uses AsyncStorage as the storage engine.
+ */
+const lifecyclePersist: PersistConfig<LifecycleState> = {
+  key: 'lifecycle',
+  storage: AsyncStorage
+};
+
+/**
+ * Persisted reducer for the instance slice.
+ */
+export const lifecycleReducer = persistReducer(
+  lifecyclePersist,
+  lifecycleSlice.reducer
+);
+
+/**
  * Exports the actions for the lifecycle slice.
  */
 export const {setLifecycle, resetLifecycle} = lifecycleSlice.actions;
-
-export const {reducer: lifecycleReducer} = lifecycleSlice;
 
 /**
  * Select the current wallet lifecycle.

--- a/ts/features/wallet/utils/attestation.ts
+++ b/ts/features/wallet/utils/attestation.ts
@@ -1,0 +1,16 @@
+import {WalletInstanceAttestation} from '@pagopa/io-react-native-wallet';
+
+/**
+ * Checks if the Wallet Instance Attestation needs to be requested by
+ * checking the expiry date
+ * @param attestation - the Wallet Instance Attestation to validate
+ * @returns true if the Wallet Instance Attestation is valid, false otherwise
+ */
+export const isWalletInstanceAttestationValid = (
+  attestation: string
+): boolean => {
+  const {payload} = WalletInstanceAttestation.decode(attestation);
+  const expiryDate = new Date(payload.exp * 1000);
+  const now = new Date();
+  return now < expiryDate;
+};


### PR DESCRIPTION
> [!CAUTION]
> This needs an app reinstallation in order to work as we don't currently manage store migrations.

## Short description

Include a summary of the changes.

## List of changes proposed in this pull request

- Update the `getAttestation` saga which now checks if an existing wallet instance attestation exists and if it does, it checks its validity before trying to obtain a new one. It returns the existing one or the newly generated one which is also set in the attestation state;
- Remove the wallet instance attestation request when creating a new wallet instance;
- Add a call to `getAttestation` whenever required, thus when obtaining the PID or a generic credential;
- Remove the wallet instance attestation existence from the presentation flow as it's not needed;
- Add the missing persistence for the `instance` slice;
-  Refactor the `lifecycle` persistence by moving it directly in its slice instead persisting the whole wallet slice and using the whitelist parameter;

## How to test
- Uninstall the app if you have it and reinstall it;
- Try to obtain a PID and a credential.
