### PR TITLE
chore: [WLEO-328] Added more debug info during startup saga

### DIFF
--- a/ts/saga/startup.ts
+++ b/ts/saga/startup.ts
@@ -59,11 +59,13 @@ function* startIdentification() {
       startIdentificationBootSplashHideDone: true
     })
   );
+  yield* put(sagaRecordStartupDebugInfo({startupIdentificationCaught : 'no'}))
   const action = yield* take([
     setIdentificationIdentified,
     setIdentificationUnidentified
   ]);
   if (setIdentificationIdentified.match(action)) {
+    yield* put(sagaRecordStartupDebugInfo({startupIdentificationCaught : 'identified'}))
     yield* fork(walletSaga);
     /*
      * This debug variable is used to check if the waitForNavigationToBeReady call terminates
@@ -74,6 +76,7 @@ function* startIdentification() {
     yield* put(startupSetStatus('DONE'));
     yield* call(handlePendingDeepLink);
   } else {
+    yield* put(sagaRecordStartupDebugInfo({startupIdentificationCaught : 'unidentified'}))
     throw new Error('Identification failed'); // Temporary error which should be mapped
   }
 }

--- a/ts/store/utils/debug.ts
+++ b/ts/store/utils/debug.ts
@@ -44,6 +44,11 @@ type StartupDebugInfo = {
    */
   startupCatchSectionBootSplashHideDone?: boolean;
   /**
+   * This variable monitors if an action between {@link setIdentificationIdentified} or {@link setIdentificationUnidentified}
+   * has been caught by the startIdentification subsaga
+   */
+  startupIdentificationCaught?: 'no' | 'identified' | 'unidentified'
+  /**
    * This variable tracks the termination status of the {@link waitForNavigationToBeReady} function call in the startup saga.
    */
   isNavigatorReady?: boolean;
@@ -73,7 +78,8 @@ const dummyInfo: StartupDebugInfo = {
   startupCatchSectionBootSplashHideDone: true,
   rootStackNavigatorStartupDone: '',
   i18nInitialized: true,
-  isNavigatorReady: false
+  isNavigatorReady: false,
+  startupIdentificationCaught : 'no'
 };
 
 const keys = Object.keys(dummyInfo);


### PR DESCRIPTION
## Short description

 Added more debug info during startup saga to check if the `setIdentificationIdentified` action dispatched from `IdentificationModal` is intercepted by the `startIdentification` subsaga.

## List of changes proposed in this pull request

- Added a new monitor variable in the startup saga.

## How to test

Check that any recorded startup info does not remain on the debug info menu after startup or a successful presentation
