### PR TITLE
fix: [WLEO-470] Moved dispatching of the `setInstanceCreationSuccess` out of the `if`

### DIFF
--- a/ts/features/wallet/saga/instance.ts
+++ b/ts/features/wallet/saga/instance.ts
@@ -51,10 +51,10 @@ export function* handleCreateInstance() {
         appFetch
       });
       yield* put(setInstanceKeyTag(keyTag));
-      yield* put(setInstanceCreationSuccess());
       // Reset the credential state before obtaining a new PID
       yield* put(resetCredentials());
     }
+    yield* put(setInstanceCreationSuccess());
   } catch (err: unknown) {
     yield* put(setInstanceCreationError({error: serializeError(err)}));
   }


### PR DESCRIPTION

## Short description

This PR solves a bug for which, in case of a failed PID issuance or a PID removal, a new PID flow would get stuck on the first screen. The bug was caused by the fact that such first screen waits for a `setInstanceCreationSuccess` action to progress to the next screens, but that action is dispatched only when the wallet instance does not already exist, so the flow will progress only the first time.

## List of changes proposed in this pull request

- Moved `setInstanceCreationSuccess` dispatching out of the `if(!instanceKeyTag)` in the `instance` saga.

## How to test

1. Reset the wallet from the settings (reinstalling the app won't clear the `instanceKeyTag`).
2. Start the PID flow, set a wrong username and password.
3. Try to obtain a PID, the flow **should not** block.
4. Delete the PID.
5. Re-obtain the PID, the flow **should not** block.
6. Reset the wallet and obtain a PID, the flow **should not** block.
7. Obtain another credential, the process **should** succeed.