### PR TITLE
fix: [WLEO-328] Possible fix to the authentication issue 

### DIFF
--- a/ts/features/wallet/saga/presentation.ts
+++ b/ts/features/wallet/saga/presentation.ts
@@ -12,11 +12,7 @@ import {
   setPreDefinitionRequest
 } from '../store/presentation';
 import {selectCredentials} from '../store/credentials';
-import {
-  setIdentificationIdentified,
-  setIdentificationStarted,
-  setIdentificationUnidentified
-} from '../../../store/reducers/identification';
+import {setIdentificationIdentified} from '../../../store/reducers/identification';
 import {
   handleDcqlRequest,
   handleDcqlResponse,
@@ -27,6 +23,7 @@ import {
   PresentationResponseProcessor,
   RequestObject
 } from '../utils/presentation';
+import {startSequentializedIdentificationProcess} from '../../../utils/identification';
 
 /**
  * Saga watcher for presentation related actions.
@@ -142,14 +139,12 @@ function* handleResponse<T>(
 
   if (setPostDefinitionRequest.match(choice)) {
     const {payload: optionalClaims} = choice;
-    yield* put(
-      setIdentificationStarted({canResetPin: false, isValidatingTask: true})
-    );
 
-    const resAction = yield* take([
-      setIdentificationIdentified,
-      setIdentificationUnidentified
-    ]);
+    const resChannel = yield* call(startSequentializedIdentificationProcess, {
+      canResetPin: false,
+      isValidatingTask: true
+    });
+    const resAction = yield* take(resChannel);
 
     if (setIdentificationIdentified.match(resAction)) {
       const authResponse: AuthResponse = yield call(

--- a/ts/utils/identification.ts
+++ b/ts/utils/identification.ts
@@ -1,0 +1,45 @@
+import {actionChannel, put, take} from 'typed-redux-saga';
+import {Channel} from 'redux-saga';
+import {
+  setIdentificationIdentified,
+  setIdentificationStarted,
+  setIdentificationUnidentified
+} from '../store/reducers/identification';
+
+type SetIdentificationStartedArgs = Parameters<
+  typeof setIdentificationStarted
+>[0];
+
+/**
+ * This utility function handles proper sequentialization of the identification process by using a {@link Channel}
+ * which buffers {@link setIdentificationIdentified} and {@link setIdentificationUnidentified} actions.
+ *
+ * Sequentialization (in form of buffering) is needed because of a race condition for which,
+ * after starting the identification flow by dispatching a {@link setIdentificationStarted} actions,
+ * the {@link setIdentificationIdentified} and {@link setIdentificationUnidentified} action are dispatched
+ * before the saga starts listening for them, leading to a deadlock.
+ *
+ * To guarantee correct sequentialization, the identification process result actions MUST be taken from the
+ * return channel
+ *
+ * @param payload The arguments of the {@link setIdentificationStarted} action
+ * @returns An action channel which buffers {@link setIdentificationIdentified} and {@link setIdentificationUnidentified} actions.
+ *          The channel MUST be used to {@link take} the identification result
+ */
+export function* startSequentializedIdentificationProcess(
+  payload: SetIdentificationStartedArgs
+) {
+  /**
+   * To ensure sequentialization, setup the listeners for the actions that will be fired after {@link setIdentificationStarted}
+   */
+  const channel = yield* actionChannel([
+    setIdentificationIdentified,
+    setIdentificationUnidentified
+  ]);
+  /**
+   * Put the {@link setIdentificationStarted} action
+   */
+  yield* put(setIdentificationStarted(payload));
+  // Return the channel for further processing
+  return channel;
+}


### PR DESCRIPTION
## Short description

This PR tries to solve the startup biometric identification soft lock by adding a stricter sequentialization to the identification flow through creating a substitute helper method, `startSequentializedIdentificationProcess`, which, in order, sets up an action channel for the identification result actions, starts the identification flow, and returns the action channel to the caller, which will use it to take the results.

The action channel is needed because a race condition may happen for which the `setIdentificationIdentified` or `setIdentificationUnidentified` actions are dispatched before the saga `take`s them.

## List of changes proposed in this pull request

- `ts/utils/identification.ts` : Added the `startSequentializedIdentificationProcess` method.
- wallet saga files: Replaced plain `setIdentificationStarted` dispatching with the new helper method invocation and modified the sagas to `take` the identification results from the helper method returned `actionChannel`.

## How to test

The changes have been tested on a device where the race condition could be reproduced _almost deterministically_ by holding the finger on the biometric sensor before starting the application, and it has been checked that repeating the same procedure after applying the fix solves the problem _almost deterministically_.

### Definition: _almost deterministically_
> In this context _almost deterministically_ means that a procedure gave the same result for at least five consecutive times, and there is no recorded evidence that the procedure gave a different result.