### PR TITLE
chore: [WLEO-492] Add patch for x5c parameter in SD-JWT parser

### DIFF
--- a/.yarn/patches/@pagopa-io-react-native-wallet-npm-1.7.1-9b4f95122b.patch
+++ b/.yarn/patches/@pagopa-io-react-native-wallet-npm-1.7.1-9b4f95122b.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sd-jwt/types.ts b/src/sd-jwt/types.ts
+index 3857aa6ea94feba4f6142522010ffd2511a6f3c6..02b793a3202aaeeb6ea8ad47c85f87c4a94e2257 100644
+--- a/src/sd-jwt/types.ts
++++ b/src/sd-jwt/types.ts
+@@ -49,7 +49,7 @@ export const SdJwt4VC = z.object({
+     typ: CredentialFormat,
+     alg: z.string(),
+     kid: z.string().optional(),
+-    x5c: z.string().optional(),
++    x5c: z.array(z.string()).optional(),
+     vctm: z.array(z.string()).optional(),
+   }),
+   payload: z.intersection(

--- a/.yarn/patches/PATCHES.md
+++ b/.yarn/patches/PATCHES.md
@@ -2,7 +2,7 @@
 
 This file describes the reason for the patches applied.
 
-### @pagopa/io-react-native-wallet+1.7.1
+### @pagopa-io-react-native-wallet-npm-1.7.1-9b4f95122b.patch
 
 Created on **11/07/2025**
 

--- a/.yarn/patches/PATCHES.md
+++ b/.yarn/patches/PATCHES.md
@@ -1,0 +1,12 @@
+## Description
+
+This file describes the reason for the patches applied.
+
+### @pagopa/io-react-native-wallet+1.7.1
+
+Created on **11/07/2025**
+
+#### Reason:
+
+- The `x5c` field in the `Header` type was changed from `z.string()` to `z.array(z.string())` to accommodate multiple certificates in the SD-JWT header. This change
+  will be implemented in the next version of the library and thus this patch can be removed once the library is updated.

--- a/package.json
+++ b/package.json
@@ -113,5 +113,8 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "yarn@3.6.4"
+  "packageManager": "yarn@3.6.4",
+  "resolutions": {
+    "@pagopa/io-react-native-wallet@1.7.1": "patch:@pagopa/io-react-native-wallet@npm%3A1.7.1#./.yarn/patches/@pagopa-io-react-native-wallet-npm-1.7.1-9b4f95122b.patch"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,6 +2769,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pagopa/io-react-native-wallet@patch:@pagopa/io-react-native-wallet@npm%3A1.7.1#./.yarn/patches/@pagopa-io-react-native-wallet-npm-1.7.1-9b4f95122b.patch::locator=ioeudiwapp%40workspace%3A.":
+  version: 1.7.1
+  resolution: "@pagopa/io-react-native-wallet@patch:@pagopa/io-react-native-wallet@npm%3A1.7.1#./.yarn/patches/@pagopa-io-react-native-wallet-npm-1.7.1-9b4f95122b.patch::version=1.7.1&hash=749041&locator=ioeudiwapp%40workspace%3A."
+  dependencies:
+    "@types/jsrsasign": ^10.5.15
+    ajv: ^8.17.1
+    dcql: ^0.2.22
+    js-base64: ^3.7.7
+    js-sha256: ^0.9.0
+    jsonpath-plus: ^10.3.0
+    jsrsasign: ^11.1.0
+    parse-url: ^9.2.0
+    react-native-url-polyfill: ^2.0.0
+    react-native-uuid: ^2.0.1
+    zod: ^3.21.4
+  peerDependencies:
+    "@pagopa/io-react-native-cbor": "*"
+    "@pagopa/io-react-native-crypto": "*"
+    "@pagopa/io-react-native-jwt": "*"
+    react: "*"
+    react-native: "*"
+  checksum: 1727aed2592e7e97aacbab638cb6b616dc1534d62a6fccc3d4532a586deaa06e45d0f0949f65d33383040b841d5b5a99feae6b9121ac20f053bc991f5ce369ed
+  languageName: node
+  linkType: hard
+
 "@pagopa/react-native-nodelibs@npm:^0.1.0":
   version: 0.1.0
   resolution: "@pagopa/react-native-nodelibs@npm:0.1.0"


### PR DESCRIPTION
## Short description
This PR adds a patch for the `x5c` parameter in the SD-JWT parser.

## List of changes proposed in this pull request

- Change the `x5c` paramter in the SD-JWT parser in array of strings. It will be remove once we update `io-react-native-wallet`;
- Add a `PATCHES.md` file with the patch description.

## How to test
Run `yarn` and then try to obtain a PID.
