### PR TITLE
feat: [WLEO-499] Added a new component to render string array claims

### DIFF
--- a/ts/features/wallet/components/credential/CredentialClaims.tsx
+++ b/ts/features/wallet/components/credential/CredentialClaims.tsx
@@ -335,14 +335,13 @@ export const StringArrayClaimItem = ({
         }
       : undefined;
 
-    const formattedClaims = [
-      claim[0],
-      claim.length >= 2 ? claim[1] : null,
-      claim.length >= 3 ? '...' : null
-    ]
-      .filter(Boolean)
-      .join(', ');
-
+  const formattedClaims = [
+    claim[0],
+    claim.length >= 2 ? claim[1] : null,
+    claim.length >= 3 ? '...' : null
+  ]
+    .filter(Boolean)
+    .join(', ');
 
   return (
     <>

--- a/ts/features/wallet/components/credential/CredentialClaims.tsx
+++ b/ts/features/wallet/components/credential/CredentialClaims.tsx
@@ -335,21 +335,25 @@ export const StringArrayClaimItem = ({
         }
       : undefined;
 
-  const checkFirstClaim = claim.length >= 1 ? claim[0] : '';
-  const checkSecondClaim =
-    checkFirstClaim + (claim.length >= 2 ? `, ${claim[1]}` : '');
-  const checkThirdClaim = checkSecondClaim + (claim.length >= 3 ? ', ...' : '');
+    const formattedClaims = [
+      claim[0],
+      claim.length >= 2 ? claim[1] : null,
+      claim.length >= 3 ? '...' : null
+    ]
+      .filter(Boolean)
+      .join(', ');
+
 
   return (
     <>
       <ListItemInfo
         label={label}
-        value={checkThirdClaim}
+        value={formattedClaims}
         endElement={endElement}
-        accessibilityLabel={`${label} ${checkThirdClaim}`}
+        accessibilityLabel={`${label} ${formattedClaims}`}
         reversed={reversed}
       />
-      {verificationBottomSheet.bottomSheet}
+      {claim.length > 2 && verificationBottomSheet.bottomSheet}
     </>
   );
 };

--- a/ts/hooks/useBottomSheet.tsx
+++ b/ts/hooks/useBottomSheet.tsx
@@ -44,6 +44,7 @@ type BottomSheetOptions = {
   component: React.ReactNode;
   title: string | React.ReactNode;
   snapPoint?: NonEmptyArray<number | string>;
+  maxDynamicContentSizePercent?: number;
   footer?: React.ReactElement;
   fullScreen?: boolean;
   onDismiss?: () => void;
@@ -62,6 +63,7 @@ export const useIOBottomSheetModal = ({
   component,
   title,
   snapPoint,
+  maxDynamicContentSizePercent = 1,
   footer,
   onDismiss
 }: Omit<BottomSheetOptions, 'fullScreen'>): IOBottomSheetModal => {
@@ -129,7 +131,10 @@ export const useIOBottomSheetModal = ({
         ) : null
       }
       enableDynamicSizing={snapPoint ? false : true}
-      maxDynamicContentSize={screenHeight - insets.top}
+      maxDynamicContentSize={
+        (screenHeight - insets.top) *
+        Math.min(Math.max(maxDynamicContentSizePercent, 0.25), 1)
+      }
       snapPoints={snapPoint}
       ref={bottomSheetModalRef}
       handleComponent={_ => header}


### PR DESCRIPTION
## Short description

This PR adds a `StringArrayItem` component that handles the rendering of a claim which consists of an array of string values in the context of the `CredentialClaims` component.

## List of changes proposed in this pull request

- `ts/features/wallet/components/credential/CredentialClaims.tsx` : Added the aforementioned new `StringArrayItem` component, which renders, in preview, at most the first two elements contained in the claim, and, in case there are more, displays a modal to show the list of all the claim's values.

- `ts/hooks/useBottomSheet.tsx` : added a new `maxDynamicContentSizePercent` prop which is a percentage applied to the value used in the `maxDynamicContentSize` prop of the `BottomSheetModal` component.

## How to test

Obtain a PID and an FBK badge and assert the following:

> **_Note_**: the checks on the credential claims fields are based on the fact that, for the time being, these claims are string array claims that contain a single element, two elements or more than two elements, but in time their values might change.

- The `nationality` field should be displayed correctly in both the PID's `PresentationCredentialDetails` and the `CredentialTrust` screens. More specifically, the *Show* button on the right **should not** be present.
- In the FBK Badge's `PresentationCredentialDetails` screen the `Locations` and `Qualifications` entries **should** display a comma-separated list of two values and an ellipsis, a *Show* button **should** be present on the right and, when clicked, a `BottomSheetModal` containing all the values in the claim **should** be shown. On top of that, the `Benefits` screen **should** display a comma-separated list of two items and there **should not** be an *Show* button on the right.
- (testable only by modifying the source code or changing the credential on the QEAA Provider side) add a number of claims that would cause an overflow on any of the aforementioned claims and **assert** that the `BottomSheetModal` does not grow for more than approximatively the 75% of the screen height, and **assert** that all elements are visible by scrolling. (**_Note_**: this has been tested on local builds).