### PR TITLE
fix(credential): add the credential name to claim in obtain credential flow

### DIFF
--- a/libs/it-wallet/src/lib/components/presentation/ItwRequiredClaimsList.tsx
+++ b/libs/it-wallet/src/lib/components/presentation/ItwRequiredClaimsList.tsx
@@ -38,7 +38,7 @@ const ItwRequiredClaimsList = ({ items }: ItwRequiredClaimsListProps) => {
             <View>
               <ClaimText claim={claim} />
               <BodySmall weight="Regular" color={theme['textBody-tertiary']}>
-                {t('credentialIssuance.trust.dataSource.single', {
+                {t('credentialIssuance.trust.dataSource', {
                   credentialSource: source,
                   ns: 'wallet'
                 })}

--- a/libs/it-wallet/src/lib/components/presentation/ItwRequiredClaimsList.tsx
+++ b/libs/it-wallet/src/lib/components/presentation/ItwRequiredClaimsList.tsx
@@ -38,8 +38,8 @@ const ItwRequiredClaimsList = ({ items }: ItwRequiredClaimsListProps) => {
             <View>
               <ClaimText claim={claim} />
               <BodySmall weight="Regular" color={theme['textBody-tertiary']}>
-                {t('credentialIssuance.trust.dataSource', {
-                  source,
+                {t('credentialIssuance.trust.dataSource.single', {
+                  credentialSource: source,
                   ns: 'wallet'
                 })}
               </BodySmall>

--- a/libs/it-wallet/src/lib/screens/credentialIssuance/CredentialTrust.tsx
+++ b/libs/it-wallet/src/lib/screens/credentialIssuance/CredentialTrust.tsx
@@ -144,7 +144,7 @@ const CredentialTrust = () => {
   const requiredClaimsByCredential = presentationDetails.map(detail =>
     detail.claimsToDisplay.map(claim => ({
       claim,
-      source: getCredentialNameFromType(detail.id, '')
+      source: getCredentialNameFromType(detail.vct, '')
     }))
   );
 

--- a/libs/it-wallet/src/locales/it/wallet.json
+++ b/libs/it-wallet/src/locales/it/wallet.json
@@ -337,10 +337,7 @@
         "store": "I tuoi dati sono al sicuro e saranno trattati solo per le finalità descritte in informativa Privacy.",
         "retention": "I dati saranno condivisi solo per il tempo necessario al rilascio della versione digitale del documento."
       },
-      "dataSource": {
-        "single": "Fornito da {{credentialSource}}",
-        "multi": "Forniti da {{credentialSource}}"
-      }
+      "dataSource": "Fornito da {{credentialSource}}"
     },
     "failure": {
       "title": "An unexpected error occurred",

--- a/libs/it-wallet/src/locales/it/wallet.json
+++ b/libs/it-wallet/src/locales/it/wallet.json
@@ -337,7 +337,10 @@
         "store": "I tuoi dati sono al sicuro e saranno trattati solo per le finalità descritte in informativa Privacy.",
         "retention": "I dati saranno condivisi solo per il tempo necessario al rilascio della versione digitale del documento."
       },
-      "dataSource": "Forniti da {{source}}"
+      "dataSource": {
+        "single": "Fornito da {{credentialSource}}",
+        "multi": "Forniti da {{credentialSource}}"
+      }
     },
     "failure": {
       "title": "An unexpected error occurred",


### PR DESCRIPTION
## Short description

In the obtain credential flow, the claim's data source now displays the actual credential name instead of an empty/incorrect value. The source is now resolved from the credential's `vct` (instead of `id`), and the `dataSource` localized string was split into `single`/`multi` variants for correct singular/plural wording.

## List of changes proposed in this pull request

  - Resolve the claim data source from `detail.vct` instead of `detail.id` in`CredentialTrust`, so the correct credential name is shown.
  - Restructure the `credentialIssuance.trust.dataSource` locale key into `single` ("Fornito da {{credentialSource}}") and `multi` ("Forniti da {{credentialSource}}") variants/
  - Update `ItwRequiredClaimsList` to use the new `dataSource.single` key and the renamed `credentialSource` interpolation variable.

## How to test

1. Start an obtain credential flow that reaches the trust/claims screen.
2. On the required claims list, verify each claim shows "Fornito da <credential name>" with the correct credential name (no longer empty).


Resolves [WLS-137](https://pagopa.atlassian.net/jira/software/c/projects/WLS/boards/6061?selectedIssue=WLS-137)


[WLS-137]: https://pagopa.atlassian.net/browse/WLS-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ