### PR TITLE
feat: Generalize PARI Bonus label and add new action button to PARI Bonus Credential details screen

### DIFF
--- a/libs/it-wallet/src/lib/components/presentation/ItwPresentationDetailsFooter.tsx
+++ b/libs/it-wallet/src/lib/components/presentation/ItwPresentationDetailsFooter.tsx
@@ -5,19 +5,28 @@ import { View } from 'react-native';
 import { useItwRemoveCredentialWithConfirm } from '../../hooks/useItwRemoveCredentialWithConfirm';
 import { useNotAvailableToastGuard } from '../../hooks/useNotAvailableToastGuard';
 import { StoredCredential } from '../../utils/itwTypesUtils';
+import { ItwCredentialCapabilities } from '../../utils/itwCredentialCapabilities';
+import { useAppSelector } from '../../store';
 
 type ItwPresentationDetailFooterProps = {
   credential: StoredCredential;
+  capabilities: ItwCredentialCapabilities;
 };
 
 const ItwPresentationDetailsFooter = ({
-  credential
+  credential,
+  capabilities
 }: ItwPresentationDetailFooterProps) => {
   const { confirmAndRemoveCredential } =
     useItwRemoveCredentialWithConfirm(credential);
 
   return (
     <View>
+      {capabilities
+        .getExtraCredentialActions?.(useAppSelector)
+        .map(({ key, props }) => (
+          <ListItemAction key={key} {...props} />
+        ))}
       <ListItemAction
         testID="requestAssistanceActionTestID"
         variant="primary"

--- a/libs/it-wallet/src/lib/screens/presentation/ItwPresentationCredentialDetailScreen.tsx
+++ b/libs/it-wallet/src/lib/screens/presentation/ItwPresentationCredentialDetailScreen.tsx
@@ -229,7 +229,10 @@ const ItwPresentationCredentialDetail = ({
             credential={credential}
             parsedClaims={parsedClaims}
           />
-          <ItwPresentationDetailsFooter credential={credential} />
+          <ItwPresentationDetailsFooter
+            credential={credential}
+            capabilities={capabilities}
+          />
           <View style={{ alignItems: 'center' }}>
             <PoweredByItWalletText />
           </View>

--- a/libs/it-wallet/src/lib/utils/itwClaimsUtils.ts
+++ b/libs/it-wallet/src/lib/utils/itwClaimsUtils.ts
@@ -82,7 +82,11 @@ export enum WellKnownClaim {
   /**
    *  Claim that contains the barcode
    */
-  barcode = 'barcode'
+  barcode = 'barcode',
+  /**
+   *  Claim that contains the fiscal code
+   */
+  personal_administrative_number = 'personal_administrative_number'
 }
 
 /**

--- a/libs/it-wallet/src/lib/utils/itwClaimsUtils.ts
+++ b/libs/it-wallet/src/lib/utils/itwClaimsUtils.ts
@@ -82,11 +82,7 @@ export enum WellKnownClaim {
   /**
    *  Claim that contains the barcode
    */
-  barcode = 'barcode',
-  /**
-   *  Claim that contains the fiscal code
-   */
-  personal_administrative_number = 'personal_administrative_number'
+  barcode = 'barcode'
 }
 
 /**

--- a/libs/it-wallet/src/lib/utils/itwCredentialCapabilities.ts
+++ b/libs/it-wallet/src/lib/utils/itwCredentialCapabilities.ts
@@ -1,5 +1,12 @@
 import type { ParseKeys } from 'i18next';
+import I18n from 'i18next';
 import { wellKnownCredential } from './credentials';
+import { IOToast, type ListItemAction } from '@pagopa/io-app-design-system';
+import { openWebUrl } from '@io-eudiw-app/commons';
+import { useAppSelector } from '../store';
+import { selectCredential } from '../store/credentials';
+import { WellKnownClaim } from './itwClaimsUtils';
+import z from 'zod';
 
 export type CredentialInfoAlert = {
   testID: string;
@@ -21,6 +28,9 @@ export type ItwCredentialCapabilities = {
   suppressStatusAlert: boolean;
   infoAlert?: CredentialInfoAlert;
   invalidStatusFailure?: CredentialInvalidStatusFailure;
+  getExtraCredentialActions?: (
+    appSelectorHook: typeof useAppSelector
+  ) => { key: string; props: ListItemAction }[];
 };
 
 const DEFAULT_CAPABILITIES: ItwCredentialCapabilities = {
@@ -63,6 +73,46 @@ const itwCredentialCapabilities: Record<string, ItwCredentialCapabilities> = {
       actionI18nKey:
         'wallet:credentialIssuance.failure.bonusPariNotRequested.action',
       actionUrl: 'https://dev.bonuselettrodomestici.it/utente'
+    },
+    getExtraCredentialActions: appSelectorHook => {
+      const credential = appSelectorHook(
+        selectCredential(wellKnownCredential.PID)
+      );
+
+      const fiscalCode = z
+        .string()
+        .safeParse(
+          credential?.parsedCredential[
+            WellKnownClaim.personal_administrative_number
+          ].value
+        );
+
+      return [
+        {
+          key: 'PARI_BONUS_CTA_1',
+          props: {
+            testID: 'PARI_BONUS_CTA_1_TESTID',
+            variant: 'primary',
+            icon: 'history',
+            label: I18n.t(
+              'presentation.credentialDetails.actions.pariPurchases',
+              { ns: 'wallet' }
+            ),
+            accessibilityLabel: I18n.t(
+              'presentation.credentialDetails.actions.pariPurchases',
+              { ns: 'wallet' }
+            ),
+            onPress: () => {
+              fiscalCode.success
+                ? openWebUrl(
+                    `https://dev.bonuselettrodomestici.it/utente/it-wallet/payment/${fiscalCode.data}`,
+                    () => IOToast.error('ERROR')
+                  )
+                : IOToast.error('ERROR');
+            }
+          }
+        }
+      ];
     }
   }
 };

--- a/libs/it-wallet/src/lib/utils/itwCredentialCapabilities.ts
+++ b/libs/it-wallet/src/lib/utils/itwCredentialCapabilities.ts
@@ -76,15 +76,13 @@ const itwCredentialCapabilities: Record<string, ItwCredentialCapabilities> = {
     },
     getExtraCredentialActions: appSelectorHook => {
       const credential = appSelectorHook(
-        selectCredential(wellKnownCredential.PID)
+        selectCredential(wellKnownCredential.BONUS_PARI)
       );
 
       const fiscalCode = z
         .string()
         .safeParse(
-          credential?.parsedCredential[
-            WellKnownClaim.personal_administrative_number
-          ].value
+          credential?.parsedCredential[WellKnownClaim.fiscal_code]?.value
         );
 
       return [
@@ -106,9 +104,10 @@ const itwCredentialCapabilities: Record<string, ItwCredentialCapabilities> = {
               fiscalCode.success
                 ? openWebUrl(
                     `https://dev.bonuselettrodomestici.it/utente/it-wallet/payment/${fiscalCode.data}`,
-                    () => IOToast.error('ERROR')
+                    () =>
+                      IOToast.error(I18n.t('errors.generic', { ns: 'common' }))
                   )
-                : IOToast.error('ERROR');
+                : IOToast.error(I18n.t('errors.generic', { ns: 'common' }));
             }
           }
         }

--- a/libs/it-wallet/src/locales/it/wallet.json
+++ b/libs/it-wallet/src/locales/it/wallet.json
@@ -16,7 +16,7 @@
       "mdl": "Patente di guida",
       "pid": "IT-Wallet ID",
       "disabilityCard": "Carta Europea della Disabilità",
-      "bonusPari": "Bonus Elettrodomestici",
+      "bonusPari": "Bonus",
       "unknown": "Credenziale Sconosciuta"
     },
     "status": {
@@ -164,7 +164,8 @@
       "actions": {
         "removeFromWallet": "Rimuovi dal Portafoglio",
         "requestAssistance": "Qualcosa non torna?",
-        "hideClaimValues": "Nascondi gli attributi del documento"
+        "hideClaimValues": "Nascondi gli attributi del documento",
+        "pariPurchases": "Dettaglio acquisti"
       },
       "dialogs": {
         "remove": {
@@ -348,7 +349,7 @@
       },
       "bonusPariNotRequested": {
         "title": "Per ottenere il documento devi prima richiedere il bonus sul portale PARI",
-        "subtitle": "Per ottenere il Bonus Elettrodomestici come documento su IT-Wallet, effettua la procedura sul portale PARI.",
+        "subtitle": "Per ottenere il Bonus come documento su IT-Wallet, effettua la procedura sul portale PARI.",
         "action": "Effettua la richiesta"
       },
       "button": "I understand"


### PR DESCRIPTION
## Short description

This PR refines the PARI process' UI by giving the bonus credential a more generic name (_"Bonus"_ instead of _"Bonus Elettrodomestici"_) and adds an action in the credential that allows the user to reach the transactions' list portal.

Solves WLS-148.

## List of changes proposed in this pull request

- Renamed the _"Bonus Elettrodomestici"_ label to a more generic _"Bonus"_ one.
- Extended `ItwCredentialCapabilities` with a `getExtraCredentialActions` property that generates a list of credential specific `ListItemAction` props, consumed by `ItwPresentationCredentialDetailsFooter`.

## How to test

Try to obtain a PARI Bonus credential, and assert the following:

- The credential's title is _"Bonus"_.
- The PARI bonus contains an extra _"Dettaglio acquisti"_ action in its details' screen that leads to the transactions page on the PARI website.
- All the other credentials' details' screens don't contain the aforementioned action.