### PR TITLE
chore: Switch from Linking.openURL to WebBrowser.openAuthSessionAsync for PARI action

### DIFF
--- a/libs/commons/src/lib/utils/url.ts
+++ b/libs/commons/src/lib/utils/url.ts
@@ -1,4 +1,6 @@
 import { Linking } from 'react-native';
+import { isAndroid } from './device';
+import * as WebBrowser from 'expo-web-browser';
 
 /**
  * Checks if the given URL is an HTTP URL.
@@ -45,4 +47,38 @@ const openWebUrl = (url: string, onError: () => void) => {
     });
 };
 
-export { openWebUrl };
+const warmUp = async () => {
+  // On Android check if there is a browser to open the authentication session and then warm it up
+  if (isAndroid) {
+    const { browserPackages } =
+      await WebBrowser.getCustomTabsSupportingBrowsersAsync();
+    if (browserPackages.length === 0) {
+      throw new Error('No browser found to open the authentication session');
+    }
+  }
+  await WebBrowser.warmUpAsync();
+};
+
+/**
+ * Opens the given URL in the default browser. If the URL cannot be opened, calls the `onError` callback.
+ * @param url - The URL to open.
+ * @param onError - The callback to call if the URL cannot be opened.
+ */
+const openWebUrlInApp = (url: string, onError: () => void) => {
+  warmUp()
+    .then(() => {
+      if (isHttp(url)) {
+        return WebBrowser.openAuthSessionAsync(url);
+      } else {
+        throw new Error('Cannot open URL');
+      }
+    })
+    .then(() => {
+      // Do nothing on success
+    })
+    .catch(_ => {
+      onError();
+    });
+};
+
+export { openWebUrl, openWebUrlInApp };

--- a/libs/it-wallet/src/lib/utils/itwCredentialCapabilities.ts
+++ b/libs/it-wallet/src/lib/utils/itwCredentialCapabilities.ts
@@ -2,7 +2,7 @@ import type { ParseKeys } from 'i18next';
 import I18n from 'i18next';
 import { wellKnownCredential } from './credentials';
 import { IOToast, type ListItemAction } from '@pagopa/io-app-design-system';
-import { openWebUrl } from '@io-eudiw-app/commons';
+import { openWebUrlInApp } from '@io-eudiw-app/commons';
 import { useAppSelector } from '../store';
 import { selectCredential } from '../store/credentials';
 import { WellKnownClaim } from './itwClaimsUtils';
@@ -102,7 +102,7 @@ const itwCredentialCapabilities: Record<string, ItwCredentialCapabilities> = {
             ),
             onPress: () => {
               fiscalCode.success
-                ? openWebUrl(
+                ? openWebUrlInApp(
                     `https://dev.bonuselettrodomestici.it/utente/it-wallet/payment/${fiscalCode.data}`,
                     () =>
                       IOToast.error(I18n.t('errors.generic', { ns: 'common' }))


### PR DESCRIPTION

## Short description

This PR fixes a problem in the PARI bonus _"Dettaglio acquisti"_ action by switching from `Linking.openURL` to `WebBrowser.openAuthSessionAsync` in order to avoid opening the browser app to access the transaction list.

## List of changes proposed in this pull request

- `url.ts` : Add `warmUp` and `openWebUrlInApp`, inspired by the pid issuance middleware, as an alternative way to open web urls for other apps.
- Applied `openWebUrlInApp` to PARI Bonus's extra action.

## How to test

Obtain a PARI bonus on both Platforms, go to its details' screen, and check that on click of the _"Dettaglio acquisti"_ action the web page is opened in a custom tab instead of a browser app.